### PR TITLE
Allow auth with X-API-KEY header instead of Authorization header

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -79,6 +79,12 @@ export default class RequestHandler {
     if (authorizationHeader === `Bearer ${this.settings.apiKey}`) {
       return true;
     }
+    
+    const apiKeyHeader = req.get("X-API-KEY");
+    if (apiKeyHeader === this.settings.apiKey) {
+      return true;
+    }
+
     return false;
   }
 


### PR DESCRIPTION
Resolves discussion #60

_I also have pending changes to turn this on & off via a setting. Let me know if you would like me to commit those._

_Part of me also wants to add a setting to make this user-customizable (eg something other than `X-API-KEY`) but maybe this is fine. Again, let me know your thoughts._