### PR TITLE
Add support for type and recursive options

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -79,11 +79,9 @@ export default class RequestHandler {
     const authorizationHeader = req.get(
       this.settings.authorizationHeaderName ?? "Authorization"
     );
-    if (authorizationHeader === `Bearer ${this.settings.apiKey}`) {
-      return true;
-    }
+    return authorizationHeader === `Bearer ${this.settings.apiKey}`;
 
-    return false;
+
   }
 
   async authenticationMiddleware(
@@ -137,7 +135,7 @@ export default class RequestHandler {
     message,
     errorCode,
   }: ErrorResponseDescriptor): string {
-    let errorMessages: string[] = [];
+    const errorMessages: string[] = [];
     if (errorCode) {
       errorMessages.push(ERROR_CODE_MESSAGES[errorCode]);
     } else {


### PR DESCRIPTION
Add support for directory and recursive parameters.
* `type=file | folder` filters for files/folders
* `recursive=true` returns the recursive list of files and directories

Let me know what else needs to be done to merge this. 

also, I had to change the obsidian npm import to `obsidian: latest` in the package.json to get things to work locally.

Thanks for the work on this!