### PR TITLE
fix: Handle PatchFailed error in PATCH request

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export const ERROR_CODE_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.MissingOperation]: "No 'Operation' header was provided.",
   [ErrorCode.InvalidOperation]:
     "The 'Operation' header you provided was invalid.",
+  [ErrorCode.PatchFailed]: "Application of this patch has failed.",
 };
 
 export enum ContentTypes {

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -537,11 +537,16 @@ export default class RequestHandler {
       createTargetIfMissing,
     } as PatchInstruction;
 
-    const patched = applyPatch(fileContents, instruction);
-
-    await this.app.vault.adapter.write(path, patched);
-
-    res.status(200).send(patched);
+    try {
+      const patched = applyPatch(fileContents, instruction);
+      await this.app.vault.adapter.write(path, patched);
+      res.status(200).send(patched);
+    } catch (e) {
+      this.returnCannedResponse(res, {
+        statusCode: 500,
+        message: e.name == "PatchFailed" ? `Patch failed: ${e.reason}` : e.message,
+      });
+    }
   }
 
   async _vaultPatch(

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -24,6 +24,7 @@ import path from "path";
 import {
   applyPatch,
   ContentType,
+  PatchFailed,
   PatchInstruction,
   PatchOperation,
   PatchTargetType,
@@ -542,10 +543,17 @@ export default class RequestHandler {
       await this.app.vault.adapter.write(path, patched);
       res.status(200).send(patched);
     } catch (e) {
-      this.returnCannedResponse(res, {
-        statusCode: 500,
-        message: e.name == "PatchFailed" ? `Patch failed: ${e.reason}` : e.message,
-      });
+      if (e instanceof PatchFailed) {
+        this.returnCannedResponse(res, {
+          errorCode: ErrorCode.PatchFailed,
+          message: e.message,
+        });
+      } else {
+        this.returnCannedResponse(res, {
+          statusCode: 500,
+          message: e.message,
+        });
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export enum ErrorCode {
   InvalidOperation = 40057,
   PeriodIsNotEnabled = 40060,
   InvalidFilterQuery = 40070,
+  PatchFailed = 40080,
   ApiKeyAuthorizationRequired = 40101,
   PeriodDoesNotExist = 40460,
   PeriodicNoteDoesNotExist = 40461,


### PR DESCRIPTION
Currently, PatchFailed errors in PATCH requests are not properly handled, causing uncaught promise rejections:

```
plugin:obsidian-local-rest-api:57202 Uncaught (in promise) PatchFailed
    at applyPatch2 (plugin:obsidian-local-rest-api:57202:19)
    at RequestHandler.eval (plugin:obsidian-local-rest-api:57821:60)
    at Generator.next (<anonymous>)
    at fulfilled (plugin:obsidian-local-rest-api:70:24)
```

This PR adds error handling to properly catch and return these errors to the client, including the specific reason for patch failures in the API response.

The change wraps the `applyPatch` call in a try-catch block and uses the existing `returnCannedResponse` method to return a consistent error format.
