### PR TITLE
modification so that a GET request to “/openapi.yaml” returns the openapi.yaml

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -51,5 +51,8 @@ esbuild
     sourcemap: prod ? false : "inline",
     treeShaking: true,
     outfile: "main.js",
+	loader: {
+      ".yaml": "text", // Added to handle handle .yaml files as text
+    },	
   })
   .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "obsidian-dataview": "^0.5.47",
     "query-string": "^7.1.1",
     "response-time": "^2.3.2",
-    "uuid": "^8.3.2",
-    "axios": "^1.6.0"
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "obsidian-dataview": "^0.5.47",
     "query-string": "^7.1.1",
     "response-time": "^2.3.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "axios": "^1.6.0"
   }
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module "*.yaml" {
+  const content: string;
+  export default content;
+}

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -152,7 +152,7 @@ export default class RequestHandler {
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> {
-    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`, "/openapi.yaml"];
+    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`];
 
     if (
       !authenticationExemptRoutes.includes(req.path) &&

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -21,7 +21,7 @@ import responseTime from "response-time";
 import queryString from "query-string";
 import WildcardRegexp from "glob-to-regexp";
 import path from "path";
-import axios from "axios";
+import axios from "axios"; // Add this import at the top
 import {
   applyPatch,
   ContentType,
@@ -152,13 +152,7 @@ export default class RequestHandler {
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> {
-    // Routes that do not require authentication.
-    // /openapi.yaml is public so that OpenAPI tools and docs can access the API schema.
-    const authenticationExemptRoutes: string[] = [
-      "/",
-      `/${CERT_NAME}`,
-      "/openapi.yaml", // Publicly accessible OpenAPI schema
-    ];
+    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`];
 
     if (
       !authenticationExemptRoutes.includes(req.path) &&

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -21,7 +21,6 @@ import responseTime from "response-time";
 import queryString from "query-string";
 import WildcardRegexp from "glob-to-regexp";
 import path from "path";
-import axios from "axios"; // Add this import at the top
 import {
   applyPatch,
   ContentType,
@@ -256,10 +255,10 @@ export default class RequestHandler {
       certificateInfo:
         this.requestIsAuthenticated(req) && certificate
           ? {
-            validityDays: getCertificateValidityDays(certificate),
-            regenerateRecommended:
-              !getCertificateIsUptoStandards(certificate),
-          }
+              validityDays: getCertificateValidityDays(certificate),
+              regenerateRecommended:
+                !getCertificateIsUptoStandards(certificate),
+            }
           : undefined,
       apiExtensions: this.requestIsAuthenticated(req)
         ? this.apiExtensions.map(({ manifest }) => manifest)
@@ -1259,20 +1258,6 @@ export default class RequestHandler {
 
     this.api.get(`/${CERT_NAME}`, this.certificateGet.bind(this));
     this.api.get("/", this.root.bind(this));
-
-    // Serve /openapi.yaml from remote URL for compatibility
-    this.api.get("/openapi.yaml", async (req, res) => {
-      try {
-        const response = await axios.get(
-          "https://coddingtonbear.github.io/obsidian-local-rest-api/openapi.yaml",
-          { responseType: "text" }
-        );
-        res.setHeader("Content-Type", "application/yaml");
-        res.send(response.data);
-      } catch (err) {
-        res.status(404).send("openapi.yaml not found");
-      }
-    });
 
     this.api.use(this.apiExtensionRouter);
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -152,7 +152,7 @@ export default class RequestHandler {
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> {
-    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`];
+    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`, "/openapi.yaml"];
 
     if (
       !authenticationExemptRoutes.includes(req.path) &&

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -56,6 +56,9 @@ import {
 } from "./constants";
 import LocalRestApiPublicApi from "./api";
 
+// Import openapi.yaml as a string
+import openapiYaml from "../docs/openapi.yaml";
+
 export default class RequestHandler {
   app: App;
   api: express.Express;
@@ -255,10 +258,10 @@ export default class RequestHandler {
       certificateInfo:
         this.requestIsAuthenticated(req) && certificate
           ? {
-              validityDays: getCertificateValidityDays(certificate),
-              regenerateRecommended:
-                !getCertificateIsUptoStandards(certificate),
-            }
+            validityDays: getCertificateValidityDays(certificate),
+            regenerateRecommended:
+              !getCertificateIsUptoStandards(certificate),
+          }
           : undefined,
       apiExtensions: this.requestIsAuthenticated(req)
         ? this.apiExtensions.map(({ manifest }) => manifest)
@@ -1173,6 +1176,12 @@ export default class RequestHandler {
   }
 
   setupRouter() {
+    // Serve /openapi.yaml unauthenticated
+    this.api.get("/openapi.yaml", (req, res) => {
+      res.setHeader("Content-Type", "application/yaml; charset=utf-8");
+      res.status(200).send(openapiYaml);
+    });
+
     this.api.use((req, res, next) => {
       const originalSend = res.send;
       res.send = function (body, ...args) {

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -21,7 +21,6 @@ import responseTime from "response-time";
 import queryString from "query-string";
 import WildcardRegexp from "glob-to-regexp";
 import path from "path";
-import fs from "fs";
 import {
   applyPatch,
   ContentType,
@@ -256,10 +255,10 @@ export default class RequestHandler {
       certificateInfo:
         this.requestIsAuthenticated(req) && certificate
           ? {
-            validityDays: getCertificateValidityDays(certificate),
-            regenerateRecommended:
-              !getCertificateIsUptoStandards(certificate),
-          }
+              validityDays: getCertificateValidityDays(certificate),
+              regenerateRecommended:
+                !getCertificateIsUptoStandards(certificate),
+            }
           : undefined,
       apiExtensions: this.requestIsAuthenticated(req)
         ? this.apiExtensions.map(({ manifest }) => manifest)
@@ -1256,19 +1255,6 @@ export default class RequestHandler {
     this.api.route("/search/simple/").post(this.searchSimplePost.bind(this));
 
     this.api.route("/open/*").post(this.openPost.bind(this));
-
-    // New route to serve /openapi.yaml from the docs folder.
-    this.api.get("/openapi.yaml", (req, res) => {
-      const filePath = path.join(__dirname, "../docs/openapi.yaml");
-      fs.readFile(filePath, "utf8", (err, data) => {
-        if (err) {
-          res.status(500).send("Error reading openapi.yaml");
-        } else {
-          res.set("Content-Type", "application/yaml");
-          res.send(data);
-        }
-      });
-    });
 
     this.api.get(`/${CERT_NAME}`, this.certificateGet.bind(this));
     this.api.get("/", this.root.bind(this));

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -21,7 +21,7 @@ import responseTime from "response-time";
 import queryString from "query-string";
 import WildcardRegexp from "glob-to-regexp";
 import path from "path";
-import axios from "axios"; // Add this import at the top
+import axios from "axios";
 import {
   applyPatch,
   ContentType,
@@ -152,7 +152,13 @@ export default class RequestHandler {
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> {
-    const authenticationExemptRoutes: string[] = ["/", `/${CERT_NAME}`];
+    // Routes that do not require authentication.
+    // /openapi.yaml is public so that OpenAPI tools and docs can access the API schema.
+    const authenticationExemptRoutes: string[] = [
+      "/",
+      `/${CERT_NAME}`,
+      "/openapi.yaml", // Publicly accessible OpenAPI schema
+    ];
 
     if (
       !authenticationExemptRoutes.includes(req.path) &&


### PR DESCRIPTION
Increased compatibility with OpenAPI applications.
Allows direct integration with projects such as https://ObsidianAITools.com via the Obsidian-Local-Rest-API.
These projects expect either an openapi.yaml or openapi.json to be served.