### PR TITLE
Fix release zip using wrong version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           node-version: '18.x' # adjust this for your needs
 
-      # Get the version number and put it in a variable
+      # Get the version number from the tag that triggered this workflow
       - name: Get Version
         id: version
         run: |
-          echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       # Build the plugin
       - name: Build


### PR DESCRIPTION
## Summary

- Replaces `git describe --abbrev=0` with `${{ github.ref_name }}` in the **Get Version** step of the release workflow
- `git describe --abbrev=0` walks parent commits to find the most recent reachable tag, which excludes the tag that just triggered the workflow — causing the zip filename to always be one version behind
- `github.ref_name` is the tag that triggered the push event, so it always matches the current release

Fixes #31