### PR TITLE
Add opt-in last-active file fallback for /active/* endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-local-rest-api",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-local-rest-api",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@types/response-time": "^2.3.5",
@@ -2521,6 +2521,90 @@
         "esbuild-windows-arm64": "0.13.2"
       }
     },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.2.tgz",
+      "integrity": "sha512-Eh2paXUWYqf5JgikdkC0LnhtjSC8tGAz/L2kJRlMC0o3DzOBIxcmT2fdzBerdhW4roY0bOExfcO6deI1qsxI/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.2.tgz",
+      "integrity": "sha512-jqp6uXHIIAWZ8kxRqFjxyMmIE1cuSbINellwwigOgk44eLg74ls82oqjY72MbDAowPivQkOU/fF7tsyaGQf5Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.2.tgz",
+      "integrity": "sha512-bD4oAyPZdzOWEA/JoX0sAitOhjJRwhomhWMeyRyowtlVQhQleG2ijRUKTvkq4CAvSobrW5EnZxjvHNKJ5L7zJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.2.tgz",
+      "integrity": "sha512-fFJ0yc3lZyfwca+F5OPN/s+izozWryUQpN8aUMIdUkOa7UKX0h3xXrKnkDgdOo8vy3d1A6zHH0/4f2VJfEzLCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.2.tgz",
+      "integrity": "sha512-DWBZauEfjmqdfWxIacI+KBEim3ulOjtvK+WVm1bX67XlfyUVIkD915OIfT2EBhQUWmv+Z0tZZwskSMNj5DKojw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.2.tgz",
+      "integrity": "sha512-Gt2rNqqRCRh1QQC2d83KP0iWIXWQYpns7l2+41a1n0PQxXkQ5AarpjjL9mUzdXtcZauNXbUvWwBKAuBTCW+XQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/esbuild-linux-64": {
       "version": "0.13.2",
       "cpu": [
@@ -2531,6 +2615,132 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.2.tgz",
+      "integrity": "sha512-KXeyotqj9jbvCjbSpwnxDE8E8jKoBgrgbJpOvvY5Zz7Pp2fAwu/94vWQtE/jPEJndY4C4MSs+ryJLFWzmLOa4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.2.tgz",
+      "integrity": "sha512-qwXL+3NDCWiC8RMKBBETpuOWdC+pUAUS+pwg9jJmapYblLdVKkyRtwF/ogj06TdYs6riSSNikW8HK/Xs0HHbbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.2.tgz",
+      "integrity": "sha512-sx8eheRX2XC2ppNAsbQm8/VUcU8XPYGpJK0BEyRefqHONz6u5Ib2guUdOz2Wh4YlbA7oOd482lHjprXSTwUcrQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.2.tgz",
+      "integrity": "sha512-y8iZ3qy2TIAKKsZ6xSopCztHOtGW9oiYDl22vQ0UIoVWjnfRKrbSzX7Y2F94y32hSvRWle6OhAIC+UpS5nQmIA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.2.tgz",
+      "integrity": "sha512-g6AYrjBeV9OK624bw0KQ1TjHJQSW+X1Yicyd1NvDWqSFpMqKAjw7EUX4tA87mOFqv8BflPGr4f43ySgNvSVzIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.2.tgz",
+      "integrity": "sha512-hIXvFIyrqwFd6v62XSra0ctCUXDS9Tu5D6QYbvnbhEoBmvD/TmEJRYRH48/+xmRifKJLzu6aegcrjAsDmaww7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.2.tgz",
+      "integrity": "sha512-Y767LG0NFkw0sPoDVOTKC5gaj4vURjjWfSCCDV5awpXXxBKOF2zsIp3aia4KvVoivoSSeRPk3emDd0OPHuPrKg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.2.tgz",
+      "integrity": "sha512-01b59kVJUMasctn6lzswC0drchr7zO75QtF22o5w0nlOw0Zorw0loY/8i5choFuWc30gXJId9qBSc1zPvt7uEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.2.tgz",
+      "integrity": "sha512-HxyY604ytmh8NkPYyS1TdIB/bFS7DWd1hP90e8Ovo/elEdN5I13h0tyIatDYZkXKS0Ztk+9T/3h6K0fI1a/4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/escalade": {
@@ -3103,6 +3313,21 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,7 @@ export default class LocalRestApi extends Plugin {
   }
 
   onunload() {
+    this.requestHandler.teardown();
     if (this.secureServer) {
       this.secureServer.close();
     }

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -4,6 +4,7 @@ import {
   App,
   CachedMetadata,
   Command,
+  EventRef,
   PluginManifest,
   prepareSimpleSearch,
   TFile,
@@ -76,6 +77,9 @@ export default class RequestHandler {
     manifest: PluginManifest;
     api: LocalRestApiPublicApi;
   }[] = [];
+
+  lastActiveFile: TFile | null = null;
+  private activeFileEventRef: EventRef | null = null;
 
   constructor(
     app: App,
@@ -1454,11 +1458,29 @@ export default class RequestHandler {
     );
   }
 
+  /**
+   * Returns the currently active file, or the last known active file if no
+   * file is currently active. Also sets an `X-Obsidian-Note-Active` header on
+   * the response to indicate which case applies.
+   */
+  getEffectiveActiveFile(res: express.Response): TFile | null {
+    const current = this.app.workspace.getActiveFile();
+    if (current) {
+      res.set("X-Obsidian-Note-Active", "true");
+      return current;
+    }
+    if (this.lastActiveFile) {
+      res.set("X-Obsidian-Note-Active", "false");
+      return this.lastActiveFile;
+    }
+    return null;
+  }
+
   async activeFileGet(
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
+    const file = this.getEffectiveActiveFile(res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1474,7 +1496,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
+    const file = this.getEffectiveActiveFile(res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1522,7 +1544,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
+    const file = this.getEffectiveActiveFile(res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1568,7 +1590,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
+    const file = this.getEffectiveActiveFile(res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1585,7 +1607,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
+    const file = this.getEffectiveActiveFile(res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1937,7 +1959,29 @@ export default class RequestHandler {
     return;
   }
 
+  teardown() {
+    if (this.activeFileEventRef) {
+      this.app.workspace.offref(this.activeFileEventRef);
+      this.activeFileEventRef = null;
+    }
+  }
+
   setupRouter() {
+    this.activeFileEventRef = this.app.workspace.on(
+      "file-open",
+      (file: TFile | null) => {
+        if (file) {
+          this.lastActiveFile = file;
+        }
+      },
+    );
+
+    // Capture any file that is already open at setup time
+    const currentFile = this.app.workspace.getActiveFile();
+    if (currentFile) {
+      this.lastActiveFile = currentFile;
+    }
+
     this.api.use((req, res, next) => {
       const originalSend = res.send;
       res.send = function (body, ...args) {

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -1459,17 +1459,21 @@ export default class RequestHandler {
   }
 
   /**
-   * Returns the currently active file, or the last known active file if no
-   * file is currently active. Also sets an `X-Obsidian-Note-Active` header on
-   * the response to indicate which case applies.
+   * Returns the currently active file. When no file is active and the request
+   * includes `?use-last-active=true`, falls back to the last known active file.
+   * Sets an `X-Obsidian-Note-Active` response header indicating whether the
+   * returned file is currently the active one (`true`) or a fallback (`false`).
    */
-  getEffectiveActiveFile(res: express.Response): TFile | null {
+  getEffectiveActiveFile(
+    req: express.Request,
+    res: express.Response,
+  ): TFile | null {
     const current = this.app.workspace.getActiveFile();
     if (current) {
       res.set("X-Obsidian-Note-Active", "true");
       return current;
     }
-    if (this.lastActiveFile) {
+    if (req.query["use-last-active"] === "true" && this.lastActiveFile) {
       res.set("X-Obsidian-Note-Active", "false");
       return this.lastActiveFile;
     }
@@ -1480,7 +1484,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.getEffectiveActiveFile(res);
+    const file = this.getEffectiveActiveFile(req, res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1496,7 +1500,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.getEffectiveActiveFile(res);
+    const file = this.getEffectiveActiveFile(req, res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1544,7 +1548,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.getEffectiveActiveFile(res);
+    const file = this.getEffectiveActiveFile(req, res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1590,7 +1594,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.getEffectiveActiveFile(res);
+    const file = this.getEffectiveActiveFile(req, res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;
@@ -1607,7 +1611,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const file = this.getEffectiveActiveFile(res);
+    const file = this.getEffectiveActiveFile(req, res);
     if (!file) {
       this.returnCannedResponse(res, { statusCode: 404 });
       return;


### PR DESCRIPTION
## Summary
- Adds a `?use-last-active=true` query parameter to the `/active/*` endpoints. When no file is currently active, the request falls back to the most recently opened file instead of returning 404.
- Tracks the last-active file via a `file-open` workspace listener registered in `setupRouter`, with a `teardown()` cleanup wired into `onunload`.
- Responses set an `X-Obsidian-Note-Active` header (`true` for the live active file, `false` when served from the fallback) so callers can tell which they got.

## Test plan
- [ ] With a note open, GET `/active/` returns it and `X-Obsidian-Note-Active: true`.
- [ ] With no active file, GET `/active/` returns 404.
- [ ] With no active file, GET `/active/?use-last-active=true` returns the previously opened file with `X-Obsidian-Note-Active: false`.
- [ ] PUT/POST/PATCH/DELETE on `/active/` honor the same fallback behavior.
- [ ] Disabling and re-enabling the plugin does not leak the workspace event listener.