### PR TITLE
fix: pass app context to getAPI() so DataView is resolved when window.DataviewAPI is unset

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -1779,7 +1779,7 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const dataviewApi = getDataviewAPI();
+    const dataviewApi = getDataviewAPI(this.app);
 
     const handlers: Record<string, () => Promise<SearchJsonResponseItem[]>> = {
       [ContentTypes.dataviewDql]: async () => {


### PR DESCRIPTION
## Problem

`POST /search/` with `application/vnd.olrapi.dataview.dql+txt` content type currently returns **400** with body:

```
Cannot read properties of undefined (reading 'tryQuery')
```

### Reproduction

```sh
curl -k -X POST \
  -H 'Authorization: Bearer <key>' \
  -H 'Content-Type: application/vnd.olrapi.dataview.dql+txt' \
  --data 'TABLE file.name FROM ""' \
  https://127.0.0.1:27124/search/
```

## Root cause

In `src/requestHandler.ts` (`searchQueryPost`), the DataView API is resolved via `getAPI()` without an argument. Per [obsidian-dataview's `getAPI(app?: App)`](https://blacksmithgu.github.io/obsidian-dataview/api/intro/), when `app` is omitted the helper falls back to `window.DataviewAPI`, which can be `undefined` in REST/headless contexts. The handler then calls `.tryQuery(...)` on `undefined`, producing the user-facing 400 above.

## Fix

Pass `this.app` to `getAPI()` so it resolves the DataView API through the active plugin registry instead of relying on the global. The plugin registry is reliably populated when Dataview is enabled.

## Scope

- One-line change at the single call site (full diff in commit body).
- No behaviour change for callers that already had Dataview API resolved through the global.
- No changes to public API, types, or routes.

## Verification

- `npm run build` — passes (tsc + esbuild).
- `npm test` — 94/94 tests pass.
- After the fix, the curl above returns the expected JSON result for any valid DQL.