### PR TITLE
Honor userIgnoreFilters in search and tag endpoints

### DIFF
--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -72,6 +72,7 @@ export class Vault {
   _cachedRead = "";
   _files: TFile[] = [new TFile()];
   _markdownFiles: TFile[] = [];
+  config: { userIgnoreFilters: string[] } = { userIgnoreFilters: [] };
 
   adapter = new DataAdapter();
 

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -839,6 +839,76 @@ describe("requestHandler", () => {
       expect(result.body.tags).toEqual([{ name: "public", count: 1 }]);
     });
 
+    test("treats leading ! and # in user-ignore filters literally", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const bangIgnoredFile = new TFile();
+      bangIgnoredFile.path = "!ignored/hidden.md";
+      const hashIgnoredFile = new TFile();
+      hashIgnoredFile.path = "#ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, bangIgnoredFile, hashIgnoredFile];
+      app.vault.config.userIgnoreFilters = ["!ignored", "#ignored"];
+
+      const publicCache = new CachedMetadata();
+      publicCache.tags = [{ tag: "#public" }];
+      const bangIgnoredCache = new CachedMetadata();
+      bangIgnoredCache.tags = [{ tag: "#bang" }];
+      const hashIgnoredCache = new CachedMetadata();
+      hashIgnoredCache.tags = [{ tag: "#hash" }];
+
+      app.metadataCache.getFileCache = (file: TFile) => {
+        if (file.path === "visible/note.md") return publicCache;
+        if (file.path === "!ignored/hidden.md") return bangIgnoredCache;
+        if (file.path === "#ignored/hidden.md") return hashIgnoredCache;
+        return null;
+      };
+
+      const result = await request(server)
+        .get("/tags/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(200);
+
+      expect(result.body.tags).toEqual([{ name: "public", count: 1 }]);
+    });
+
+    test("does not broaden glob-style user-ignore filters to deeper folders", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const shallowIgnoredFile = new TFile();
+      shallowIgnoredFile.path = "ignored/shallow.md";
+      const nestedFile = new TFile();
+      nestedFile.path = "ignored/deep/visible.md";
+      app.vault._markdownFiles = [publicFile, shallowIgnoredFile, nestedFile];
+      app.vault.config.userIgnoreFilters = ["ignored/*"];
+
+      const publicCache = new CachedMetadata();
+      publicCache.tags = [{ tag: "#public" }];
+      const shallowIgnoredCache = new CachedMetadata();
+      shallowIgnoredCache.tags = [{ tag: "#ignored" }];
+      const nestedCache = new CachedMetadata();
+      nestedCache.tags = [{ tag: "#nested" }];
+
+      app.metadataCache.getFileCache = (file: TFile) => {
+        if (file.path === "visible/note.md") return publicCache;
+        if (file.path === "ignored/shallow.md") return shallowIgnoredCache;
+        if (file.path === "ignored/deep/visible.md") return nestedCache;
+        return null;
+      };
+
+      const result = await request(server)
+        .get("/tags/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(200);
+
+      expect(result.body.tags).toEqual(
+        expect.arrayContaining([
+          { name: "public", count: 1 },
+          { name: "nested", count: 1 },
+        ]),
+      );
+      expect(result.body.tags).not.toContainEqual({ name: "ignored", count: 1 });
+    });
+
     test("unauthorized", async () => {
       await request(server).get("/tags/").expect(401);
     });

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -785,6 +785,60 @@ describe("requestHandler", () => {
       expect(result.body.tags).toEqual([{ name: "project", count: 2 }]);
     });
 
+    test("does not aggregate tags from user-ignored folders", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const ignoredFile = new TFile();
+      ignoredFile.path = "ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, ignoredFile];
+      app.vault.config.userIgnoreFilters = ["ignored/"];
+
+      const publicCache = new CachedMetadata();
+      publicCache.tags = [{ tag: "#public" }];
+      const ignoredCache = new CachedMetadata();
+      ignoredCache.tags = [{ tag: "#ignored" }];
+
+      app.metadataCache.getFileCache = (file: TFile) => {
+        if (file.path === "visible/note.md") return publicCache;
+        if (file.path === "ignored/hidden.md") return ignoredCache;
+        return null;
+      };
+
+      const result = await request(server)
+        .get("/tags/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(200);
+
+      expect(result.body.tags).toEqual([{ name: "public", count: 1 }]);
+    });
+
+    test("supports glob-style user-ignore filters", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const ignoredFile = new TFile();
+      ignoredFile.path = "nested/ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, ignoredFile];
+      app.vault.config.userIgnoreFilters = ["**/ignored/**"];
+
+      const publicCache = new CachedMetadata();
+      publicCache.tags = [{ tag: "#public" }];
+      const ignoredCache = new CachedMetadata();
+      ignoredCache.tags = [{ tag: "#ignored" }];
+
+      app.metadataCache.getFileCache = (file: TFile) => {
+        if (file.path === "visible/note.md") return publicCache;
+        if (file.path === "nested/ignored/hidden.md") return ignoredCache;
+        return null;
+      };
+
+      const result = await request(server)
+        .get("/tags/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(200);
+
+      expect(result.body.tags).toEqual([{ name: "public", count: 1 }]);
+    });
+
     test("unauthorized", async () => {
       await request(server).get("/tags/").expect(401);
     });
@@ -1378,6 +1432,27 @@ describe("requestHandler", () => {
       expect(result.body[0].matches[1].match.end).toBe(10);   // 18 - 8
     });
 
+    test("does not return matches from user-ignored folders", async () => {
+      const publicFile = new TFile();
+      publicFile.basename = "public";
+      publicFile.path = "visible/public.md";
+      const ignoredFile = new TFile();
+      ignoredFile.basename = "hidden";
+      ignoredFile.path = "ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, ignoredFile];
+      app.vault.config.userIgnoreFilters = ["ignored"];
+      app.vault.cachedRead = async (file: TFile) =>
+        file.path === "ignored/hidden.md" ? "needle ignored" : "needle public";
+
+      const result = await request(server)
+        .post("/search/simple/?query=needle")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(200);
+
+      expect(result.body).toHaveLength(1);
+      expect(result.body[0].filename).toBe("visible/public.md");
+    });
+
     test("unauthorized", async () => {
       await request(server)
         .post("/search/simple/?query=test")
@@ -1485,6 +1560,63 @@ describe("requestHandler", () => {
 
       expect(result.body).toHaveLength(1);
       expect(result.body[0].filename).toBe("note.md");
+    });
+
+    test("does not return JSONLogic matches from user-ignored folders", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const ignoredFile = new TFile();
+      ignoredFile.path = "ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, ignoredFile];
+      app.vault.config.userIgnoreFilters = ["ignored/"];
+      app.vault.cachedRead = async (file: TFile) =>
+        file.path === "ignored/hidden.md" ? "needle ignored" : "needle public";
+
+      const cache = new CachedMetadata();
+      app.metadataCache.getFileCache = () => cache;
+
+      const result = await request(server)
+        .post("/search/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Content-Type", "application/vnd.olrapi.jsonlogic+json")
+        .send({ in: ["needle", { var: "content" }] })
+        .expect(200);
+
+      expect(result.body).toHaveLength(1);
+      expect(result.body[0].filename).toBe("visible/note.md");
+    });
+
+    test("does not expose user-ignored files through JSONLogic links and backlinks", async () => {
+      const publicFile = new TFile();
+      publicFile.path = "visible/note.md";
+      const ignoredFile = new TFile();
+      ignoredFile.path = "ignored/hidden.md";
+      app.vault._markdownFiles = [publicFile, ignoredFile];
+      app.vault.config.userIgnoreFilters = ["ignored"];
+      app.metadataCache.resolvedLinks = {
+        "visible/note.md": { "ignored/hidden.md": 1 },
+        "ignored/hidden.md": { "visible/note.md": 1 },
+      };
+
+      const cache = new CachedMetadata();
+      app.metadataCache.getFileCache = () => cache;
+
+      const linksResult = await request(server)
+        .post("/search/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Content-Type", "application/vnd.olrapi.jsonlogic+json")
+        .send({ in: ["ignored/hidden.md", { var: "links" }] })
+        .expect(200);
+
+      const backlinksResult = await request(server)
+        .post("/search/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Content-Type", "application/vnd.olrapi.jsonlogic+json")
+        .send({ in: ["ignored/hidden.md", { var: "backlinks" }] })
+        .expect(200);
+
+      expect(linksResult.body).toHaveLength(0);
+      expect(backlinksResult.body).toHaveLength(0);
     });
 
     test("returns 400 when content-type is missing", async () => {

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -25,8 +25,19 @@ const WildcardRegexp = require("glob-to-regexp") as (pattern: string) => RegExp;
 const minimatch = require("minimatch") as (
   path: string,
   pattern: string,
-  options?: { dot?: boolean; nocase?: boolean },
+  options?: { dot?: boolean; nocase?: boolean; nonegate?: boolean; nocomment?: boolean },
 ) => boolean;
+
+const USER_IGNORE_GLOB_OPTIONS = {
+  dot: true,
+  nocase: false,
+  nonegate: true,
+  nocomment: true,
+};
+
+function hasGlobMagic(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern) || /[!+@]\(/.test(pattern);
+}
 
 export class FileNotFoundError extends Error {}
 export class CommandNotFoundError extends Error {}
@@ -72,13 +83,17 @@ export class VaultOperations {
     const normalizedPath = filePath.replace(/^\/+/, "");
 
     return filters.some((rawFilter) => {
-      const filter = rawFilter.trim().replace(/^\/+|\/+$/g, "");
+      const trimmedFilter = rawFilter.trim().replace(/^\/+/, "");
+      const filter = trimmedFilter.replace(/\/+$/g, "");
       if (!filter) return false;
+
+      const isDirectoryPrefixFilter =
+        trimmedFilter.endsWith("/") || !hasGlobMagic(filter);
+
       return (
-        normalizedPath === filter ||
-        normalizedPath.startsWith(`${filter}/`) ||
-        minimatch(normalizedPath, filter, { dot: true, nocase: false }) ||
-        minimatch(normalizedPath, `${filter}/**`, { dot: true, nocase: false })
+        (isDirectoryPrefixFilter &&
+          (normalizedPath === filter || normalizedPath.startsWith(`${filter}/`))) ||
+        minimatch(normalizedPath, filter, USER_IGNORE_GLOB_OPTIONS)
       );
     });
   }

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -22,6 +22,11 @@ const jsonLogic = require("json-logic-js") as {
 };
  
 const WildcardRegexp = require("glob-to-regexp") as (pattern: string) => RegExp;
+const minimatch = require("minimatch") as (
+  path: string,
+  pattern: string,
+  options?: { dot?: boolean; nocase?: boolean },
+) => boolean;
 
 export class FileNotFoundError extends Error {}
 export class CommandNotFoundError extends Error {}
@@ -57,6 +62,31 @@ export class VaultOperations {
         return false;
       },
     );
+  }
+
+  private isUserIgnored(filePath: string): boolean {
+    const vault = this.app.vault as typeof this.app.vault & {
+      config?: { userIgnoreFilters?: string[] };
+    };
+    const filters = vault.config?.userIgnoreFilters ?? [];
+    const normalizedPath = filePath.replace(/^\/+/, "");
+
+    return filters.some((rawFilter) => {
+      const filter = rawFilter.trim().replace(/^\/+|\/+$/g, "");
+      if (!filter) return false;
+      return (
+        normalizedPath === filter ||
+        normalizedPath.startsWith(`${filter}/`) ||
+        minimatch(normalizedPath, filter, { dot: true, nocase: false }) ||
+        minimatch(normalizedPath, `${filter}/**`, { dot: true, nocase: false })
+      );
+    });
+  }
+
+  private getMarkdownFilesRespectingUserIgnoreFilters(): TFile[] {
+    return this.app.vault
+      .getMarkdownFiles()
+      .filter((file) => !this.isUserIgnored(file.path));
   }
 
   private waitForFileCache(
@@ -154,7 +184,9 @@ export class VaultOperations {
     for (const [sourcePath, targets] of Object.entries(
       this.app.metadataCache.resolvedLinks,
     )) {
+      if (this.isUserIgnored(sourcePath)) continue;
       for (const targetPath of Object.keys(targets)) {
+        if (this.isUserIgnored(targetPath)) continue;
         (index[targetPath] ??= []).push(sourcePath);
       }
     }
@@ -184,7 +216,7 @@ export class VaultOperations {
 
     const links = Object.keys(
       this.app.metadataCache.resolvedLinks[file.path] ?? {},
-    );
+    ).filter((targetPath) => !this.isUserIgnored(targetPath));
 
     const index = backlinksIndex ?? this.buildBacklinksIndex();
     const backlinks = index[file.path] ?? [];
@@ -465,7 +497,7 @@ export class VaultOperations {
     const results: SearchResponseItem[] = [];
     const search = prepareSimpleSearch(query);
 
-    for (const file of this.app.vault.getMarkdownFiles()) {
+    for (const file of this.getMarkdownFilesRespectingUserIgnoreFilters()) {
       const cachedContents = await this.app.vault.cachedRead(file);
 
       const filenamePrefix = file.basename + "\n\n";
@@ -518,7 +550,7 @@ export class VaultOperations {
     const backlinksIndex = this.buildBacklinksIndex();
     const includeContent = JSON.stringify(query).includes('"content"');
 
-    for (const file of this.app.vault.getMarkdownFiles()) {
+    for (const file of this.getMarkdownFilesRespectingUserIgnoreFilters()) {
       const fileContext = await this.getFileMetadataObject(file, backlinksIndex, includeContent);
 
       try {
@@ -545,7 +577,7 @@ export class VaultOperations {
 
   getAllTags(): Array<{ name: string; count: number }> {
     const tagCounts: Record<string, number> = {};
-    for (const file of this.app.vault.getMarkdownFiles()) {
+    for (const file of this.getMarkdownFilesRespectingUserIgnoreFilters()) {
       const cache = this.app.metadataCache.getFileCache(file);
       if (!cache) continue;
       const fileTags = getAllTags(cache);


### PR DESCRIPTION
## Summary

This makes the vault-wide search and tag aggregation paths respect Obsidian's `userIgnoreFilters` setting.

Covered surfaces:

- `/tags/`
- `/search/simple/`
- `/search/` JSONLogic queries
- JSONLogic `links` / `backlinks` metadata derived from resolved links

The matcher keeps exact folder/file-prefix behavior for plain ignore entries and also supports glob-style ignore patterns via the existing `minimatch` dependency.

## Tests

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --runInBand`

`npm run test:integration -- --runInBand` was not run to completion because the integration suite requires `OBSIDIAN_API_KEY`.
