### PR TITLE
Configure server keep-alive timeouts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
 import LocalRestApiPublicApi, { ApiVersionUnsupportedError } from "./api";
 export { ApiVersionUnsupportedError } from "./api";
 import { PluginManifest } from "obsidian";
+import { configureHttpServerTimeouts } from "./serverTimeouts";
 
 export default class LocalRestApi extends Plugin {
   settings: LocalRestApiSettings;
@@ -190,6 +191,7 @@ export default class LocalRestApi extends Plugin {
         },
         this.requestHandler.api
       );
+      configureHttpServerTimeouts(this.secureServer);
       this.secureServer.listen(
         this.settings.port,
         this.settings.bindingHost ?? DefaultBindingHost
@@ -211,6 +213,7 @@ export default class LocalRestApi extends Plugin {
     }
     if (this.settings.enableInsecureServer) {
       this.insecureServer = http.createServer(this.requestHandler.api);
+      configureHttpServerTimeouts(this.insecureServer);
       this.insecureServer.listen(
         this.settings.insecurePort,
         this.settings.bindingHost ?? DefaultBindingHost

--- a/src/serverTimeouts.test.ts
+++ b/src/serverTimeouts.test.ts
@@ -18,7 +18,7 @@ describe("HTTP server timeout configuration", () => {
       expect(server.headersTimeout).toBe(SERVER_HEADERS_TIMEOUT_MS);
       expect(server.keepAliveTimeout).toBeLessThan(server.headersTimeout);
     } finally {
-      server.close();
+      if (server.listening) server.close();
     }
   });
 });

--- a/src/serverTimeouts.test.ts
+++ b/src/serverTimeouts.test.ts
@@ -1,0 +1,24 @@
+import http from "http";
+import {
+  configureHttpServerTimeouts,
+  SERVER_HEADERS_TIMEOUT_MS,
+  SERVER_KEEP_ALIVE_TIMEOUT_MS,
+} from "./serverTimeouts";
+
+describe("HTTP server timeout configuration", () => {
+  test("sets keep-alive lower than headers timeout", () => {
+    const server = http.createServer((_req, res) => {
+      res.end("ok");
+    });
+
+    try {
+      configureHttpServerTimeouts(server);
+
+      expect(server.keepAliveTimeout).toBe(SERVER_KEEP_ALIVE_TIMEOUT_MS);
+      expect(server.headersTimeout).toBe(SERVER_HEADERS_TIMEOUT_MS);
+      expect(server.keepAliveTimeout).toBeLessThan(server.headersTimeout);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/src/serverTimeouts.ts
+++ b/src/serverTimeouts.ts
@@ -1,0 +1,10 @@
+import type http from "http";
+import type https from "https";
+
+export const SERVER_KEEP_ALIVE_TIMEOUT_MS = 60_000;
+export const SERVER_HEADERS_TIMEOUT_MS = 65_000;
+
+export function configureHttpServerTimeouts(server: http.Server | https.Server) {
+  server.keepAliveTimeout = SERVER_KEEP_ALIVE_TIMEOUT_MS;
+  server.headersTimeout = SERVER_HEADERS_TIMEOUT_MS;
+}


### PR DESCRIPTION
## Summary

- set explicit keep-alive and headers timeouts on both secure and insecure HTTP servers
- keep `headersTimeout` slightly above `keepAliveTimeout`, matching Node's recommended relationship
- add unit coverage for the timeout helper

## Why

The default Node keep-alive timeout is short. Explicitly configuring these values avoids avoidable stale-socket/RST races for clients that reuse connections.

## Tests

- `npm test -- src/serverTimeouts.test.ts --runInBand`
- `npm run typecheck`
- `npm run build`
- `npm test -- --runInBand`
- `npm run lint` (passes with one existing warning in `src/integration/patch.test.ts`)
