### PR TITLE
Fix MCP server hanging on all but the most-recently-connected session

### DIFF
--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -625,3 +625,32 @@ describe("periodic_note_get_path tool", () => {
     expect(typeof body.path).toBe("string");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-session routing (regression for shared-McpServer bug)
+// ---------------------------------------------------------------------------
+
+describe("multi-session routing", () => {
+  test("first session remains functional after a second session connects", async () => {
+    const clientA = makeClient();
+    const clientB = makeClient();
+    try {
+      await clientA.connect(makeTransport());
+      // Connecting clientB previously overwrote the shared McpServer's internal
+      // _transport reference, causing clientA's subsequent tool calls to hang
+      // indefinitely as their responses were routed to clientB's transport.
+      await clientB.connect(makeTransport());
+
+      const resultA = await clientA.callTool({ name: "vault_list", arguments: {} });
+      expect(resultA.isError).toBeFalsy();
+      expect(Array.isArray(jsonOf<{ files: string[] }>(resultA).files)).toBe(true);
+
+      const resultB = await clientB.callTool({ name: "vault_list", arguments: {} });
+      expect(resultB.isError).toBeFalsy();
+      expect(Array.isArray(jsonOf<{ files: string[] }>(resultB).files)).toBe(true);
+    } finally {
+      await clientA.close().catch((_e: unknown): void => {});
+      await clientB.close().catch((_e: unknown): void => {});
+    }
+  });
+});

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -136,11 +136,22 @@ describe("McpHandler", () => {
    
   let ops: any;
 
-  beforeEach(() => {
+  // Each session now gets its own McpServer, so tool/resource registration runs when
+  // a session is built (not at construction). Trigger one build so the McpServer mock
+  // captures the registrations that getToolCallback() reads.
+  async function buildSession(mcp: McpHandler): Promise<void> {
+    // @ts-ignore: partial mock
+    await mcp.handleRequest(
+      { headers: {}, body: { jsonrpc: "2.0", id: 0, method: "initialize" } },
+      { status: jest.fn().mockReturnThis(), json: jest.fn() },
+    );
+  }
+
+  beforeEach(async () => {
     jest.clearAllMocks();
     ops = makeMockOps();
-    // Construction registers all tools via registerTools()
-    new McpHandler(ops, DEFAULT_SETTINGS);
+    // Construction records specs; building a session registers them on a server.
+    await buildSession(new McpHandler(ops, DEFAULT_SETTINGS));
   });
 
   // ---- resource registration ----------------------------------------------
@@ -605,6 +616,9 @@ describe("McpHandler", () => {
   // ---- handleRequest ------------------------------------------------------
 
   describe("handleRequest", () => {
+    // Reset mock counts polluted by the outer beforeEach session build.
+    beforeEach(() => jest.clearAllMocks());
+
     test("returns 404 when session ID is unknown", async () => {
       const mcp = new McpHandler(ops);
       const mockRes = {
@@ -663,9 +677,10 @@ describe("McpHandler", () => {
   // ---- registerTool -------------------------------------------------------
 
   describe("registerTool", () => {
-    test("registers a tool and returns a cleanup function", () => {
+    test("registers a tool and returns a cleanup function", async () => {
       const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
       const cleanup = mcp.registerTool("my_tool", "Does something", {}, async () => "result");
+      await buildSession(mcp);
       expect(mockTool).toHaveBeenCalledWith("my_tool", "Does something", {}, expect.any(Function));
       expect(typeof cleanup).toBe("function");
     });
@@ -685,14 +700,19 @@ describe("McpHandler", () => {
       ).toThrow(/already registered/);
     });
 
-    test("cleanup removes the tool and frees the name for re-registration", () => {
+    test("cleanup removes the tool and frees the name for re-registration", async () => {
       const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
       const cleanup = mcp.registerTool("removable_tool", "Desc", {}, async () => "");
       cleanup();
-      expect(mockRemove).toHaveBeenCalledTimes(1);
+      // Name is freed for re-registration...
       expect(() =>
         mcp.registerTool("removable_tool", "Desc", {}, async () => ""),
       ).not.toThrow();
+      // ...and the cleaned-up spec is not double-registered on a fresh server.
+      jest.clearAllMocks();
+      await buildSession(mcp);
+      const removableCalls = mockTool.mock.calls.filter((c: unknown[]) => c[0] === "removable_tool");
+      expect(removableCalls).toHaveLength(1);
     });
   });
 });

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -620,7 +620,7 @@ describe("McpHandler", () => {
     beforeEach(() => jest.clearAllMocks());
 
     test("returns 404 when session ID is unknown", async () => {
-      const mcp = new McpHandler(ops);
+      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
       const mockRes = {
         status: jest.fn().mockReturnThis(),
         json: jest.fn(),
@@ -637,7 +637,7 @@ describe("McpHandler", () => {
       const { StreamableHTTPServerTransport } = jest.requireMock(
         "@modelcontextprotocol/sdk/server/streamableHttp.js",
       );
-      const mcp = new McpHandler(ops);
+      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
 
       const mockReq = { headers: {}, body: { jsonrpc: "2.0", method: "initialize" } };
       const mockRes = {};
@@ -654,7 +654,7 @@ describe("McpHandler", () => {
       const { StreamableHTTPServerTransport } = jest.requireMock(
         "@modelcontextprotocol/sdk/server/streamableHttp.js",
       );
-      const mcp = new McpHandler(ops);
+      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
 
       // Initialize: POST without session ID registers the transport via onsessioninitialized
       const initReq = { headers: {}, body: undefined };

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -23,40 +23,85 @@ interface MinimalMcpServer {
   resource(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void;
 }
 
+interface ToolSpec {
+  name: string;
+  description: string;
+  schema: unknown;
+  callback: (args: unknown) => Promise<CallToolResult>;
+}
+
+interface ResourceSpec {
+  name: string;
+  uri: string;
+  meta: unknown;
+  handler: (uri: URL) => Promise<unknown>;
+}
+
 export class McpHandler {
-  private readonly mcpServer: MinimalMcpServer;
-  private readonly transports: Map<string, StreamableHTTPServerTransport> = new Map();
+  private readonly sessions: Map<string, { server: MinimalMcpServer; transport: StreamableHTTPServerTransport }> = new Map();
   private readonly registeredToolNames = new Set<string>();
+  private readonly toolSpecs: ToolSpec[] = [];
+  private readonly resourceSpecs: ResourceSpec[] = [];
 
   constructor(
     private readonly ops: VaultOperations,
     private readonly settings: LocalRestApiSettings,
   ) {
-    this.mcpServer = new McpServer({
+    this.registerResources();
+    this.registerTools();
+  }
+
+  // Build a fresh McpServer for a single session/transport. Each transport MUST own
+  // its own server: the SDK's Server.connect() binds a single _transport, so sharing
+  // one server across multiple connected transports routes every response to the
+  // most-recently-connected transport, hanging all older sessions.
+  private buildServer(): MinimalMcpServer {
+    const server: MinimalMcpServer = new McpServer({
       name: "obsidian-local-rest-api",
       version: "1.0.0",
     });
-    this.registerResources();
-    this.registerTools();
+    for (const spec of this.resourceSpecs) {
+      server.resource(spec.name, spec.uri, spec.meta, spec.handler);
+    }
+    for (const spec of this.toolSpecs) {
+      server.tool(spec.name, spec.description, spec.schema, spec.callback);
+    }
+    return server;
+  }
+
+  private resource(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void {
+    this.resourceSpecs.push({ name, uri, meta, handler });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private tool(name: string, description: string, schema: any, callback: (args: any) => Promise<CallToolResult>): { remove: () => void } {
     this.registeredToolNames.add(name);
-    return this.mcpServer.tool(name, description, schema, async (args: unknown) => {
-      try {
-        const result = await callback(args);
-        if (this.settings.enableVerboseLogging) {
-          console.debug(`[MCP] ${name} => ok`);
+    const spec: ToolSpec = {
+      name,
+      description,
+      schema,
+      callback: async (args: unknown) => {
+        try {
+          const result = await callback(args);
+          if (this.settings.enableVerboseLogging) {
+            console.debug(`[MCP] ${name} => ok`);
+          }
+          return result;
+        } catch (e) {
+          if (this.settings.enableVerboseLogging) {
+            console.debug(`[MCP] ${name} => error`);
+          }
+          throw e;
         }
-        return result;
-      } catch (e) {
-        if (this.settings.enableVerboseLogging) {
-          console.debug(`[MCP] ${name} => error`);
-        }
-        throw e;
-      }
-    });
+      },
+    };
+    this.toolSpecs.push(spec);
+    return {
+      remove: () => {
+        const index = this.toolSpecs.indexOf(spec);
+        if (index >= 0) this.toolSpecs.splice(index, 1);
+      },
+    };
   }
 
   public registerTool(
@@ -86,26 +131,27 @@ export class McpHandler {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (!sessionId) {
+      const server = this.buildServer();
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
-          this.transports.set(id, transport);
+          this.sessions.set(id, { server, transport });
         },
       });
       transport.onclose = () => {
-        if (transport.sessionId) this.transports.delete(transport.sessionId);
+        if (transport.sessionId) this.sessions.delete(transport.sessionId);
       };
-      await this.mcpServer.connect(transport);
+      await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
       return;
     }
 
-    const transport = this.transports.get(sessionId);
-    if (!transport) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
       res.status(404).json({ error: "Session not found" });
       return;
     }
-    await transport.handleRequest(req, res, req.body);
+    await session.transport.handleRequest(req, res, req.body);
   }
 
   private text(data: unknown) {
@@ -127,7 +173,7 @@ export class McpHandler {
   }
 
   private registerResources(): void {
-    this.mcpServer.resource(
+    this.resource(
       "openapi-spec",
       "obsidian://local-rest-api/openapi.yaml",
       {

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -45,8 +45,7 @@ interface SessionEntry {
 
 export class McpHandler {
   private readonly sessions: Map<string, SessionEntry> = new Map();
-  private readonly registeredToolNames = new Set<string>();
-  private readonly toolSpecs: ToolSpec[] = [];
+  private readonly toolSpecs: Map<string, ToolSpec> = new Map();
   private readonly resourceSpecs: ResourceSpec[] = [];
 
   constructor(
@@ -70,7 +69,7 @@ export class McpHandler {
     for (const spec of this.resourceSpecs) {
       server.resource(spec.name, spec.uri, spec.meta, spec.handler);
     }
-    for (const spec of this.toolSpecs) {
+    for (const spec of this.toolSpecs.values()) {
       toolHandles.set(spec.name, server.tool(spec.name, spec.description, spec.schema, spec.callback));
     }
     return { server, toolHandles };
@@ -82,7 +81,6 @@ export class McpHandler {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private tool(name: string, description: string, schema: any, callback: (args: any) => Promise<CallToolResult>): { remove: () => void } {
-    this.registeredToolNames.add(name);
     const spec: ToolSpec = {
       name,
       description,
@@ -102,14 +100,13 @@ export class McpHandler {
         }
       },
     };
-    this.toolSpecs.push(spec);
+    this.toolSpecs.set(spec.name, spec);
     for (const session of this.sessions.values()) {
       session.toolHandles.set(spec.name, session.server.tool(spec.name, spec.description, spec.schema, spec.callback));
     }
     return {
       remove: () => {
-        const index = this.toolSpecs.indexOf(spec);
-        if (index >= 0) this.toolSpecs.splice(index, 1);
+        this.toolSpecs.delete(spec.name);
         for (const session of this.sessions.values()) {
           const handle = session.toolHandles.get(spec.name);
           if (handle) {
@@ -127,7 +124,7 @@ export class McpHandler {
     schema: Record<string, z.ZodTypeAny>,
     callback: (args: Record<string, unknown>) => Promise<unknown>,
   ): () => void {
-    if (this.registeredToolNames.has(name)) {
+    if (this.toolSpecs.has(name)) {
       throw new Error(
         `Cannot register MCP tool "${name}" — a tool with this name is already registered.`,
       );
@@ -135,10 +132,7 @@ export class McpHandler {
     const registered = this.tool(name, description, schema, async (args) =>
       this.text(await callback(args as Record<string, unknown>)),
     );
-    return () => {
-      registered.remove();
-      this.registeredToolNames.delete(name);
-    };
+    return () => registered.remove();
   }
 
   async handleRequest(

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -37,8 +37,14 @@ interface ResourceSpec {
   handler: (uri: URL) => Promise<unknown>;
 }
 
+interface SessionEntry {
+  server: MinimalMcpServer;
+  transport: StreamableHTTPServerTransport;
+  toolHandles: Map<string, { remove: () => void }>;
+}
+
 export class McpHandler {
-  private readonly sessions: Map<string, { server: MinimalMcpServer; transport: StreamableHTTPServerTransport }> = new Map();
+  private readonly sessions: Map<string, SessionEntry> = new Map();
   private readonly registeredToolNames = new Set<string>();
   private readonly toolSpecs: ToolSpec[] = [];
   private readonly resourceSpecs: ResourceSpec[] = [];
@@ -55,18 +61,19 @@ export class McpHandler {
   // its own server: the SDK's Server.connect() binds a single _transport, so sharing
   // one server across multiple connected transports routes every response to the
   // most-recently-connected transport, hanging all older sessions.
-  private buildServer(): MinimalMcpServer {
+  private buildServer(): { server: MinimalMcpServer; toolHandles: Map<string, { remove: () => void }> } {
     const server: MinimalMcpServer = new McpServer({
       name: "obsidian-local-rest-api",
       version: "1.0.0",
     });
+    const toolHandles = new Map<string, { remove: () => void }>();
     for (const spec of this.resourceSpecs) {
       server.resource(spec.name, spec.uri, spec.meta, spec.handler);
     }
     for (const spec of this.toolSpecs) {
-      server.tool(spec.name, spec.description, spec.schema, spec.callback);
+      toolHandles.set(spec.name, server.tool(spec.name, spec.description, spec.schema, spec.callback));
     }
-    return server;
+    return { server, toolHandles };
   }
 
   private resource(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void {
@@ -100,6 +107,13 @@ export class McpHandler {
       remove: () => {
         const index = this.toolSpecs.indexOf(spec);
         if (index >= 0) this.toolSpecs.splice(index, 1);
+        for (const session of this.sessions.values()) {
+          const handle = session.toolHandles.get(spec.name);
+          if (handle) {
+            handle.remove();
+            session.toolHandles.delete(spec.name);
+          }
+        }
       },
     };
   }
@@ -131,11 +145,11 @@ export class McpHandler {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (!sessionId) {
-      const server = this.buildServer();
+      const { server, toolHandles } = this.buildServer();
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
-          this.sessions.set(id, { server, transport });
+          this.sessions.set(id, { server, transport, toolHandles });
         },
       });
       transport.onclose = () => {

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -103,6 +103,9 @@ export class McpHandler {
       },
     };
     this.toolSpecs.push(spec);
+    for (const session of this.sessions.values()) {
+      session.toolHandles.set(spec.name, session.server.tool(spec.name, spec.description, spec.schema, spec.callback));
+    }
     return {
       remove: () => {
         const index = this.toolSpecs.indexOf(spec);

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -76,7 +76,7 @@ export class McpHandler {
     return { server, toolHandles };
   }
 
-  private resource(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void {
+  private addResourceSpec(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void {
     this.resourceSpecs.push({ name, uri, meta, handler });
   }
 
@@ -190,7 +190,7 @@ export class McpHandler {
   }
 
   private registerResources(): void {
-    this.resource(
+    this.addResourceSpec(
       "openapi-spec",
       "obsidian://local-rest-api/openapi.yaml",
       {


### PR DESCRIPTION
## Summary

The built-in MCP server shares **one `McpServer` instance across every session's
transport**. The MCP SDK's `Server.connect()` binds a single `_transport`, so each
new session silently repoints that reference to its own transport. From then on,
any request arriving on an **older** session has its response routed to the
**newest** session's socket — the older request never gets a reply and hangs until
the client times out (~60s), and the misrouted reply lands on the wrong session.

In practice: as soon as a second MCP client (or a reconnect, or even a second
`initialize`) connects, every previously-connected session stops working — while
still showing as "connected". This matches the reports in
#266 and #263 (timeouts/disconnects that "reconnect usually fixes", multiple
clients, intermittent).

## Root cause

`src/mcpHandler.ts` builds one server in the constructor and connects every new
session's transport to it:

```ts
await this.mcpServer.connect(transport); // shared server — rebinds _transport
```

`initialize` / `tools/list` / `resources/list` are simple request→response and keep
working (which is why the connection still looks healthy), but `tools/call` relies
on the per-session response routing that the shared `_transport` breaks.

## Fix

Give every session its own `McpServer`. Tool/resource registrations are captured
once as reusable specs at construction time and replayed onto a fresh server for
each new transport (`buildServer()`), kept paired 1:1 in the session map. The
public `registerTool()` extension API is preserved.

## Steps to reproduce

With the plugin running and the non-encrypted (HTTP) server enabled on port 27123:

```bash
TOKEN=<API_KEY>
H=(-H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -H "MCP-Protocol-Version: 2025-03-26")

# Session A — initialize, capture its session id
A=$(curl -sS -i -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"A","version":"1"}}}')
SIDA=$(echo "$A" | grep -i '^mcp-session-id:' | awk '{print $2}' | tr -d '\r')
curl -sS -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" -H "Mcp-Session-Id: $SIDA" \
  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null

# Session B — initialize (steals the shared server's _transport)
B=$(curl -sS -i -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"B","version":"1"}}}')
SIDB=$(echo "$B" | grep -i '^mcp-session-id:' | awk '{print $2}' | tr -d '\r')
curl -sS -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" -H "Mcp-Session-Id: $SIDB" \
  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null

# Tool call on the OLDER session A — hangs; on the NEWER session B — instant
curl -sS -o /dev/null -w "A: %{size_download} bytes in %{time_total}s\n" --max-time 12 \
  -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" -H "Mcp-Session-Id: $SIDA" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"vault_list","arguments":{"path":""}}}'
curl -sS -o /dev/null -w "B: %{size_download} bytes in %{time_total}s\n" --max-time 12 \
  -X POST http://127.0.0.1:27123/mcp/ "${H[@]}" -H "Mcp-Session-Id: $SIDB" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"vault_list","arguments":{"path":""}}}'
```

**Before the fix:**

```
A: 0 bytes in 12.006s     # older session hangs
B: 158 bytes in 0.004s    # newer session works
```

Packet capture on loopback confirms the older session's `tools/call` is accepted
at the TCP layer (POST body ACKed) and then gets **zero bytes** of HTTP response
until the client RSTs ~60s later, while a fresh session runs the identical tool in
single-digit milliseconds.

## Evidence the fix works

**After the fix**, the same reproduction returns results on **both** sessions:

```
A: 158 bytes in 0.007s
B: 158 bytes in 0.002s
```

Concurrency check — 10 sessions opened in sequence, then a `tools/call` fired on
every session (including the very first) plus the oldest session hammered 5 more
times:

```
opened 10 sessions
wave1 (all 10 concurrent): 10/10 ok
wave2 (oldest session x5): 5/5 ok
RESULT: 15/15 PASS
```

## Tests

`src/mcpHandler.test.ts` updated for per-session registration (tools/resources are
now registered when a session is built, not at construction). Full suite green:

- `npm test` — 187 passed
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — ok

## Related

- Discussion #266
- Discussion #263 / #251 (same shape: handshake + `tools/list` succeed, `tools/call` hangs)
