### PR TITLE
Fix: frontmatter append/prepend type-mismatch returns 500 instead of 400

### DIFF
--- a/src/vaultOperations.test.ts
+++ b/src/vaultOperations.test.ts
@@ -1,0 +1,82 @@
+import { VaultOperations, FileNotFoundError } from "./vaultOperations";
+import { App } from "../mocks/obsidian";
+import { PatchFailed, PatchFailureReason } from "markdown-patch";
+
+describe("VaultOperations.patchFileSection", () => {
+  let app: App;
+  let ops: VaultOperations;
+
+  const FIXTURE = ["---", "tags:", "  - theme/orig", "---", "", "Body text.", ""].join("\n");
+
+  beforeEach(() => {
+    app = new App();
+    app.vault._read = FIXTURE;
+    // @ts-ignore: mock App doesn't perfectly match the real Obsidian App interface
+    ops = new VaultOperations(app);
+  });
+
+  test("appending a type-mismatched scalar to a list frontmatter field throws PatchFailed(ContentNotMergeable), not a raw Error", async () => {
+    // Regression test for coddingtonbear/obsidian-local-rest-api#282: this used
+    // to escape markdown-patch's own applyPatch() as a bare
+    // `Error("Cannot merge objects of different types or unsupported types: object and string")`,
+    // which callers couldn't distinguish from a genuine server fault and which
+    // surfaced as an HTTP 500 / MCP error with no actionable message.
+    await expect(
+      ops.patchFileSection(
+        "somefile.md",
+        "frontmatter",
+        "tags",
+        "append",
+        "theme/added",
+        "application/json",
+      ),
+    ).rejects.toMatchObject({
+      constructor: PatchFailed,
+      reason: PatchFailureReason.ContentNotMergeable,
+    });
+  });
+
+  test("the PatchFailed thrown for a type mismatch preserves the original markdown-patch error as `cause`", async () => {
+    await expect(
+      ops.patchFileSection(
+        "somefile.md",
+        "frontmatter",
+        "tags",
+        "append",
+        "theme/added",
+        "application/json",
+      ),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining("Cannot merge objects"),
+      }),
+    });
+  });
+
+  test("appending a compatible array to a list frontmatter field still succeeds", async () => {
+    const patched = await ops.patchFileSection(
+      "somefile.md",
+      "frontmatter",
+      "tags",
+      "append",
+      ["theme/added"],
+      "application/json",
+    );
+    expect(patched).toContain("theme/orig");
+    expect(patched).toContain("theme/added");
+  });
+
+  test("patching a missing file still throws FileNotFoundError", async () => {
+    app.vault._getAbstractFileByPath = null;
+    await expect(
+      ops.patchFileSection(
+        "nope.md",
+        "frontmatter",
+        "tags",
+        "append",
+        ["x"],
+        "application/json",
+      ),
+    ).rejects.toBeInstanceOf(FileNotFoundError);
+  });
+});

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -11,6 +11,8 @@ import path from "path";
 import {
   applyPatch,
   getDocumentMap,
+  PatchFailed,
+  PatchFailureReason,
   PatchInstruction,
   PatchOperation,
   PatchTargetType,
@@ -402,7 +404,41 @@ export class VaultOperations {
       ...(options?.targetScope ? { targetScope: options.targetScope } : {}),
     } as PatchInstruction;
 
-    const patched = applyPatch(fileContents, instruction);
+    let patched: string;
+    try {
+      patched = applyPatch(fileContents, instruction);
+    } catch (error) {
+      // markdown-patch's own frontmatter merge guard (MergeNotPossible ->
+      // PatchFailed/ContentNotMergeable) only fires when the appended content
+      // isn't an appendable *type* at all. It doesn't cover content that IS an
+      // appendable type but incompatible with the *existing* field's type
+      // (e.g. appending a scalar string to a list-valued field): that specific
+      // case falls through mergeFrontmatterValue() as a plain `new Error(...)`
+      // (see node_modules/markdown-patch dist/patch.js), not a PatchFailed or
+      // any other subclass. Match on that exact constructor -- not just
+      // targetType/operation -- so a genuine, unrelated failure in this same
+      // code path (e.g. yaml.stringify throwing its own YAMLError subclass)
+      // still surfaces as the 500 it actually is, instead of being
+      // misreported as a 400. Preserve the original error as `cause` for
+      // debuggability.
+      if (
+        targetType === "frontmatter" &&
+        (operation === "append" || operation === "prepend") &&
+        error instanceof Error &&
+        error.constructor === Error
+      ) {
+        const patchFailed = new PatchFailed(
+          PatchFailureReason.ContentNotMergeable,
+          instruction,
+          null,
+        );
+        // tsconfig's lib target predates ES2022's Error.cause; cast rather
+        // than bump the lib target for one debugging-only field.
+        (patchFailed as Error & { cause?: unknown }).cause = error;
+        throw patchFailed;
+      }
+      throw error;
+    }
     await this.app.vault.adapter.write(filePath, patched);
     return patched;
   }


### PR DESCRIPTION
## Problem

Closes #282.

`PATCH` with `Target-Type: frontmatter` and `Operation: append`/`prepend` returns an
unhandled **500** (instead of a clean 400) when the value being appended is incompatible
with the existing field's type — e.g. appending a string onto a field that already holds
a list.

## Root cause

`mergeFrontmatterValue()` throws a bare `Error` in this case (append-able type, but
incompatible with the existing field type). That error was never caught at the shared
REST/MCP call site in `VaultOperations.patchFileSection`, so it propagated up and was
reported as a generic 500.

## Fix

Catch the specific `Error` thrown by `mergeFrontmatterValue()` at the `frontmatter`
append/prepend call site and re-report it as `PatchFailed(ContentNotMergeable)`, which
maps to a `400`/`errorCode 40080` response. The guard is scoped narrowly:

- Only matches `error.constructor === Error` (the exact class thrown by
  `mergeFrontmatterValue`), so other failure types (e.g. a `YAMLError` from
  `yaml.stringify`) still surface as genuine 500s.
- Only applies to `targetType === "frontmatter"` with `append`/`prepend`.
- Preserves the original error via `.cause` for debugging.

## Testing

- Added `src/vaultOperations.test.ts` with 4 cases covering the type-mismatch scenario
  and confirming unrelated errors are unaffected.
- Full suite: 197/197 passing.
- Typecheck/lint clean.