### PR TITLE
Add COPY method for vault files

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
 | `vault_delete` | Delete a vault file |
 | `vault_move` | Move (rename) a vault file to a new path |
+| `vault_copy` | Copy a vault file to a new path |
 | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
 | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |
 | `periodic_note_get_path` | Return the vault path of the current periodic note (`daily`, `weekly`, `monthly`, `quarterly`, `yearly`) |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1062,6 +1062,7 @@ paths:
         | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
         | `vault_delete` | Delete a vault file |
         | `vault_move` | Move (rename) a vault file to a new path |
+        | `vault_copy` | Copy a vault file to a new path |
         | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
         | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |
         | `periodic_note_get_path` | Return the vault path of the current periodic note (daily, weekly, monthly, quarterly, yearly) |
@@ -3351,6 +3352,74 @@ paths:
         - "Vault Directories"
   "/vault/{filename}":
     additionalOperations:
+      copy:
+        description: |
+          Copies a file from its current location to a new location specified in the Destination header, leaving the source file in place.
+        parameters:
+          - description: |
+              The new path for the copy, relative to your vault root. The path must not escape the vault root (relative segments like `..` are permitted as long as the resolved path remains inside the vault). Absolute paths (starting with `/`) are rejected. If the path ends with a trailing slash, the source filename is preserved and the copy is placed in that directory (e.g. "archive/" copies "notes/todo.md" to "archive/todo.md"). If the path contains non-ASCII characters (e.g. accented letters), percent-encode the value (e.g. `r%C3%A9sum%C3%A9.md` for `résumé.md`).
+            in: "header"
+            name: "Destination"
+            required: true
+            schema:
+              format: "path"
+              type: "string"
+          - description: |
+              If "true", the copy proceeds even when a file already exists at the destination. Defaults to "false", which returns a 409 if the destination exists.
+            in: "header"
+            name: "Allow-Overwrite"
+            required: false
+            schema:
+              default: "false"
+              enum:
+                - "true"
+                - "false"
+              type: "string"
+          - description: "Path to the relevant file (relative to your vault root).\n Optionally, you may include a reference to target a sub-part of the document; see \"Targeting a Sub-part of your Document\" for details."
+            in: "path"
+            name: "filename"
+            required: true
+            schema:
+              format: "path"
+              type: "string"
+        responses:
+          "204":
+            description: "File successfully copied."
+            headers:
+              Content-Location:
+                description: "The vault-relative path of the newly-created copy (e.g. `archive/file.md`). Non-ASCII characters are percent-encoded."
+                schema:
+                  type: "string"
+          "400":
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/Error"
+            description: |
+              Bad request - Missing Destination header, malformed percent-encoding, or path escapes the vault root (e.g. starts with "/").
+          "404":
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/Error"
+            description: "Source file does not exist."
+          "405":
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/Error"
+            description: |
+              Your path references a directory instead of a file; this request method is valid only for files.
+          "409":
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/Error"
+            description: "Destination file already exists."
+        summary: |
+          Copy a file to a new location in your vault.
+        tags:
+          - "Vault Files"
       move:
         description: |
           Moves a file from its current location to a new location specified in the Destination header. This operation preserves file history and updates internal links.

--- a/docs/src/lib/copy.jsonnet
+++ b/docs/src/lib/copy.jsonnet
@@ -1,0 +1,83 @@
+{
+  tags: [
+    'Vault Files',
+  ],
+  summary: 'Copy a file to a new location in your vault.\n',
+  description: 'Copies a file from its current location to a new location specified in the Destination header, leaving the source file in place.\n',
+  parameters: [
+    {
+      name: 'Destination',
+      'in': 'header',
+      description: 'The new path for the copy, relative to your vault root. The path must not escape the vault root (relative segments like `..` are permitted as long as the resolved path remains inside the vault). Absolute paths (starting with `/`) are rejected. If the path ends with a trailing slash, the source filename is preserved and the copy is placed in that directory (e.g. "archive/" copies "notes/todo.md" to "archive/todo.md"). If the path contains non-ASCII characters (e.g. accented letters), percent-encode the value (e.g. `r%C3%A9sum%C3%A9.md` for `résumé.md`).\n',
+      required: true,
+      schema: {
+        type: 'string',
+        format: 'path',
+      },
+    },
+    {
+      name: 'Allow-Overwrite',
+      'in': 'header',
+      description: 'If "true", the copy proceeds even when a file already exists at the destination. Defaults to "false", which returns a 409 if the destination exists.\n',
+      required: false,
+      schema: {
+        type: 'string',
+        enum: ['true', 'false'],
+        default: 'false',
+      },
+    },
+  ],
+  responses: {
+    '204': {
+      description: 'File successfully copied.',
+      headers: {
+        'Content-Location': {
+          description: 'The vault-relative path of the newly-created copy (e.g. `archive/file.md`). Non-ASCII characters are percent-encoded.',
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+    },
+    '400': {
+      description: 'Bad request - Missing Destination header, malformed percent-encoding, or path escapes the vault root (e.g. starts with "/").\n',
+      content: {
+        'application/json': {
+          schema: {
+            '$ref': '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    '404': {
+      description: 'Source file does not exist.',
+      content: {
+        'application/json': {
+          schema: {
+            '$ref': '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    '405': {
+      description: 'Your path references a directory instead of a file; this request method is valid only for files.\n',
+      content: {
+        'application/json': {
+          schema: {
+            '$ref': '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    '409': {
+      description: 'Destination file already exists.',
+      content: {
+        'application/json': {
+          schema: {
+            '$ref': '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+  },
+}

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -15,6 +15,7 @@ Include the `MCP-Protocol-Version` header on all requests after initialization, 
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
 | `vault_delete` | Delete a vault file |
 | `vault_move` | Move (rename) a vault file to a new path |
+| `vault_copy` | Copy a vault file to a new path |
 | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
 | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |
 | `periodic_note_get_path` | Return the vault path of the current periodic note (daily, weekly, monthly, quarterly, yearly) |

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -1,3 +1,4 @@
+local Copy = import 'lib/copy.jsonnet';
 local Delete = import 'lib/delete.jsonnet';
 local Get = import 'lib/get.jsonnet';
 local Move = import 'lib/move.jsonnet';
@@ -242,6 +243,9 @@ std.manifestYamlDoc(
         additionalOperations: {
           move: Move {
             parameters: Move.parameters + [ParamPath],
+          },
+          copy: Copy {
+            parameters: Copy.parameters + [ParamPath],
           },
         },
         delete: Delete {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "obsidian-local-rest-api",
 	"name": "Local REST API with MCP",
 	"version": "4.1.7",
-	"minAppVersion": "1.4.0",
+	"minAppVersion": "1.8.7",
 	"description": "A secure REST API and Model Context Protocol (MCP) server for your vault.",
 	"author": "Adam Coddington",
 	"authorUrl": "https://adamcoddington.net/",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const ERROR_CODE_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.ErrorPreparingSimpleSearch]:
     "Error encountered while calling Obsidian `prepareSimpleSearch` API.",
   [ErrorCode.MissingDestinationHeader]:
-    "Destination header is required for MOVE operations.",
+    "Destination header is required for MOVE and COPY operations.",
   [ErrorCode.InvalidDestinationHeader]:
     "The 'Destination' header you provided could not be parsed.",
   [ErrorCode.PathTraversalNotAllowed]:

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -101,6 +101,7 @@ function makeMockOps() {
     executeCommand: jest.fn(),
     openVaultFile: jest.fn(),
     moveVaultFile: jest.fn().mockResolvedValue(""),
+    copyVaultFile: jest.fn().mockResolvedValue(""),
     periodicGetNote: jest.fn().mockReturnValue([mockFile, null]),
     periodicGetOrCreateNote: jest.fn().mockResolvedValue([mockFile, null]),
   };
@@ -175,8 +176,8 @@ describe("McpHandler", () => {
 
   // ---- tool registration --------------------------------------------------
 
-  test("registers all 16 tools", () => {
-    expect(mockTool).toHaveBeenCalledTimes(16);
+  test("registers all 17 tools", () => {
+    expect(mockTool).toHaveBeenCalledTimes(17);
     const names = mockTool.mock.calls.map((c: unknown[]) => c[0]);
     expect(names).toEqual(
       expect.arrayContaining([
@@ -187,6 +188,7 @@ describe("McpHandler", () => {
         "vault_patch",
         "vault_delete",
         "vault_move",
+        "vault_copy",
         "vault_get_document_map",
         "active_file_get_path",
         "periodic_note_get_path",
@@ -223,8 +225,8 @@ describe("McpHandler", () => {
       }
     });
 
-    test("vault_patch, vault_delete, vault_move, and command_execute are annotated as destructive", () => {
-      for (const name of ["vault_patch", "vault_delete", "vault_move", "command_execute"]) {
+    test("vault_patch, vault_delete, vault_move, vault_copy, and command_execute are annotated as destructive", () => {
+      for (const name of ["vault_patch", "vault_delete", "vault_move", "vault_copy", "command_execute"]) {
         const annotations = getToolAnnotations(name);
         expect(annotations.readOnlyHint).toBe(false);
         expect(annotations.destructiveHint).toBe(true);
@@ -633,6 +635,75 @@ describe("McpHandler", () => {
     test("propagates FileNotFoundError from moveVaultFile", async () => {
       ops.moveVaultFile.mockRejectedValue(new Error("File not found: missing.md"));
       const cb = getToolCallback("vault_move");
+      await expect(cb({ path: "missing.md", destination: "dest.md" })).rejects.toThrow(
+        "File not found",
+      );
+    });
+  });
+
+  // ---- vault_copy -----------------------------------------------------------
+
+  describe("vault_copy", () => {
+    test("copies file and returns source and new paths", async () => {
+      ops.copyVaultFile.mockResolvedValue("archive/file.md");
+      const cb = getToolCallback("vault_copy");
+      const result = await cb({ path: "folder/file.md", destination: "archive/file.md" });
+      expect(ops.copyVaultFile).toHaveBeenCalledWith("folder/file.md", "archive/file.md", false);
+      const parsed = parseText(result);
+      expect(parsed.message).toBe("OK");
+      expect(parsed.sourcePath).toBe("folder/file.md");
+      expect(parsed.newPath).toBe("archive/file.md");
+    });
+
+    test("trailing-slash destination uses source filename", async () => {
+      ops.copyVaultFile.mockResolvedValue("archive/todo.md");
+      const cb = getToolCallback("vault_copy");
+      const result = await cb({ path: "notes/todo.md", destination: "archive/" });
+      expect(ops.copyVaultFile).toHaveBeenCalledWith("notes/todo.md", "archive/todo.md", false);
+      expect(parseText(result).newPath).toBe("archive/todo.md");
+    });
+
+    test("passes allowOverwrite flag", async () => {
+      const cb = getToolCallback("vault_copy");
+      await cb({ path: "a.md", destination: "b.md", allowOverwrite: true });
+      expect(ops.copyVaultFile).toHaveBeenCalledWith("a.md", "b.md", true);
+    });
+
+    test("empty destination copies to vault root preserving source filename", async () => {
+      ops.copyVaultFile.mockResolvedValue("todo.md");
+      const cb = getToolCallback("vault_copy");
+      const result = await cb({ path: "notes/todo.md", destination: "" });
+      expect(ops.copyVaultFile).toHaveBeenCalledWith("notes/todo.md", "todo.md", false);
+      expect(parseText(result).newPath).toBe("todo.md");
+    });
+
+    test("rejects path traversal in destination", async () => {
+      const cb = getToolCallback("vault_copy");
+      await expect(cb({ path: "a.md", destination: "../../../etc/passwd" })).rejects.toThrow(
+        "must not escape the vault root",
+      );
+      expect(ops.copyVaultFile).not.toHaveBeenCalled();
+    });
+
+    test("rejects absolute destination", async () => {
+      const cb = getToolCallback("vault_copy");
+      await expect(cb({ path: "a.md", destination: "/etc/passwd" })).rejects.toThrow(
+        "must not escape the vault root",
+      );
+      expect(ops.copyVaultFile).not.toHaveBeenCalled();
+    });
+
+    test("allows destination with '..' as a substring (not a segment)", async () => {
+      ops.copyVaultFile.mockResolvedValue("archive/notes..md");
+      const cb = getToolCallback("vault_copy");
+      const result = await cb({ path: "a.md", destination: "archive/notes..md" });
+      expect(ops.copyVaultFile).toHaveBeenCalledWith("a.md", "archive/notes..md", false);
+      expect(parseText(result).newPath).toBe("archive/notes..md");
+    });
+
+    test("propagates FileNotFoundError from copyVaultFile", async () => {
+      ops.copyVaultFile.mockRejectedValue(new Error("File not found: missing.md"));
+      const cb = getToolCallback("vault_copy");
       await expect(cb({ path: "missing.md", destination: "dest.md" })).rejects.toThrow(
         "File not found",
       );

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -492,6 +492,65 @@ export class McpHandler {
     );
 
     this.tool(
+      "vault_copy",
+      dedent`Copy a vault file to a new path. Creates any missing parent directories at the destination automatically. Throws if the source file does not exist.`,
+      {
+        path: z.string().describe("Source file path relative to vault root"),
+        destination: z
+          .string()
+          .describe(
+            dedent`Destination path relative to vault root; must not escape the vault root. May end with '/' to preserve the source filename in the target directory (e.g. destination 'archive/' copies 'notes/todo.md' to 'archive/todo.md').`,
+          ),
+        allowOverwrite: z
+          .boolean()
+          .optional()
+          .describe(
+            dedent`If true, copy proceeds even when a file already exists at the destination; otherwise the copy throws (default: false).`,
+          ),
+      },
+      { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+      async ({
+        path,
+        destination,
+        allowOverwrite,
+      }: {
+        path: string;
+        destination: string;
+        allowOverwrite?: boolean;
+      }) => {
+        const normalized = destination
+          .trim()
+          .replace(/\\/g, "/")
+          .replace(/\/+/g, "/");
+
+        if (normalized.startsWith("/")) {
+          throw new Error(
+            "Destination path must be relative and must not escape the vault root.",
+          );
+        }
+
+        const syntheticRoot = "/vault";
+        const resolved = posix.resolve(syntheticRoot, normalized);
+        if (resolved !== syntheticRoot && !resolved.startsWith(syntheticRoot + "/")) {
+          throw new Error(
+            "Destination path must be relative and must not escape the vault root.",
+          );
+        }
+
+        const sourceFilename = path.includes("/")
+          ? path.slice(path.lastIndexOf("/") + 1)
+          : path;
+
+        const resolvedDestination = !normalized || normalized.endsWith("/")
+          ? normalized + sourceFilename
+          : normalized;
+
+        const actualPath = await this.ops.copyVaultFile(path, resolvedDestination, allowOverwrite ?? false);
+        return this.text({ message: "OK", sourcePath: path, newPath: actualPath });
+      },
+    );
+
+    this.tool(
       "vault_get_document_map",
       dedent`Return the structure of a vault file as a document map: the list of heading paths, block reference IDs, and frontmatter field names present in the file. Use this before vault_read or vault_patch with targeting to discover what targets are available without parsing the full markdown content yourself.`,
       { path: z.string().describe("File path relative to vault root") },

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -831,6 +831,142 @@ describe("requestHandler", () => {
     });
   });
 
+  describe("vaultCopy", () => {
+    test("directory path rejected", async () => {
+      await request(server)
+        .copy("/vault/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "somewhere/file.md")
+        .expect(405);
+    });
+
+    test("successful copy", async () => {
+      const sourcePath = "folder/file.md";
+      const newPath = "another-folder/subfolder/file.md";
+      jest.spyOn(handler.operations, "copyVaultFile").mockResolvedValue(newPath);
+
+      const response = await request(server)
+        .copy(`/vault/${sourcePath}`)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", newPath)
+        .expect(204);
+
+      expect(response.headers["content-location"]).toEqual(newPath);
+      expect(handler.operations.copyVaultFile).toHaveBeenCalledWith(
+        sourcePath,
+        newPath,
+        false,
+      );
+    });
+
+    test("non-existent source file returns 404", async () => {
+      jest
+        .spyOn(handler.operations, "copyVaultFile")
+        .mockRejectedValue(new FileNotFoundError("not found"));
+
+      await request(server)
+        .copy("/vault/non-existent.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "new-location/file.md")
+        .expect(404);
+    });
+
+    test("destination already exists returns 409", async () => {
+      jest
+        .spyOn(handler.operations, "copyVaultFile")
+        .mockRejectedValue(new DestinationAlreadyExistsError("exists"));
+
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "another-folder/existing-file.md")
+        .expect(409);
+
+      expect(response.body.message).toContain("Destination file already exists");
+    });
+
+    test("missing Destination header returns 400", async () => {
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(400);
+
+      expect(response.body.message).toContain("Destination header is required");
+    });
+
+    test("destination with trailing slash uses source filename", async () => {
+      jest.spyOn(handler.operations, "copyVaultFile").mockResolvedValue("new-folder/file.md");
+
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "new-folder/")
+        .expect(204);
+
+      expect(response.headers["content-location"]).toEqual("new-folder/file.md");
+      expect(handler.operations.copyVaultFile).toHaveBeenCalledWith(
+        "folder/file.md",
+        "new-folder/file.md",
+        false,
+      );
+    });
+
+    test("Allow-Overwrite: true passes flag to copyVaultFile", async () => {
+      jest.spyOn(handler.operations, "copyVaultFile").mockResolvedValue("another-folder/existing-file.md");
+
+      await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "another-folder/existing-file.md")
+        .set("Allow-Overwrite", "true")
+        .expect(204);
+
+      expect(handler.operations.copyVaultFile).toHaveBeenCalledWith(
+        "folder/file.md",
+        "another-folder/existing-file.md",
+        true,
+      );
+    });
+
+    test("path traversal attempt returns 400", async () => {
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "../../../etc/passwd")
+        .expect(400);
+
+      expect(response.body.errorCode).toEqual(40021);
+      expect(response.body.message).toContain("Path traversal is not allowed");
+    });
+
+    test("absolute destination path returns 400", async () => {
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "/etc/passwd")
+        .expect(400);
+
+      expect(response.body.errorCode).toEqual(40021);
+    });
+
+    test("malformed percent-encoding in Destination returns 400", async () => {
+      const response = await request(server)
+        .copy("/vault/folder/file.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "%E0%")
+        .expect(400);
+
+      expect(response.body.errorCode).toEqual(40022);
+    });
+
+    test("unauthorized", async () => {
+      await request(server)
+        .copy("/vault/file.md")
+        .set("Destination", "other/file.md")
+        .expect(401);
+    });
+  });
+
   describe("vaultPatch", () => {
     test("directory", async () => {
       await request(server)
@@ -936,6 +1072,15 @@ describe("requestHandler", () => {
     test("MOVE rejects ..%2F traversal in source path with 400 and errorCode 40021", async () => {
       const res = await request(server)
         .move(traversal)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Destination", "safe/destination.md");
+      expect(res.status).toBe(400);
+      expect(res.body.errorCode).toBe(40021);
+    });
+
+    test("COPY rejects ..%2F traversal in source path with 400 and errorCode 40021", async () => {
+      const res = await request(server)
+        .copy(traversal)
         .set("Authorization", `Bearer ${API_KEY}`)
         .set("Destination", "safe/destination.md");
       expect(res.status).toBe(400);

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -870,6 +870,91 @@ export default class RequestHandler {
     return this._vaultMove(path, req, res);
   }
 
+  async _vaultCopy(
+    path: string,
+    req: express.Request,
+    res: express.Response,
+  ): Promise<void> {
+    if (!path || path.endsWith("/")) {
+      this.returnCannedResponse(res, {
+        errorCode: ErrorCode.RequestMethodValidOnlyForFiles,
+      });
+      return;
+    }
+
+    const rawDestination = req.header("Destination");
+    const allowOverwrite = req.header("Allow-Overwrite") === "true";
+
+    if (rawDestination === undefined) {
+      this.returnCannedResponse(res, {
+        errorCode: ErrorCode.MissingDestinationHeader,
+      });
+      return;
+    }
+
+    const sourceFilename = path.includes("/")
+      ? path.slice(path.lastIndexOf("/") + 1)
+      : path;
+
+    let normalized: string;
+    try {
+      normalized = decodeURIComponent(rawDestination.trim())
+        .replace(/\\/g, "/")
+        .replace(/\/+/g, "/");
+    } catch {
+      this.returnCannedResponse(res, {
+        errorCode: ErrorCode.InvalidDestinationHeader,
+      });
+      return;
+    }
+
+    if (normalized.startsWith("/")) {
+      this.returnCannedResponse(res, {
+        errorCode: ErrorCode.PathTraversalNotAllowed,
+      });
+      return;
+    }
+
+    const syntheticRoot = "/vault";
+    const resolved = posix.resolve(syntheticRoot, normalized);
+    if (resolved !== syntheticRoot && !resolved.startsWith(syntheticRoot + "/")) {
+      this.returnCannedResponse(res, {
+        errorCode: ErrorCode.PathTraversalNotAllowed,
+      });
+      return;
+    }
+
+    const newPath = !normalized || normalized.endsWith("/")
+      ? normalized + sourceFilename
+      : normalized;
+
+    try {
+      const actualPath = await this.operations.copyVaultFile(path, newPath, allowOverwrite);
+      res.set("Content-Location", encodeURI(actualPath));
+      this.returnCannedResponse(res, { statusCode: 204 });
+    } catch (error) {
+      if (error instanceof FileNotFoundError) {
+        this.returnCannedResponse(res, { statusCode: 404 });
+      } else if (error instanceof DestinationAlreadyExistsError) {
+        this.returnCannedResponse(res, {
+          errorCode: ErrorCode.DestinationAlreadyExists,
+        });
+      } else {
+        const msg = error instanceof Error ? error.message : String(error);
+        this.returnCannedResponse(res, {
+          errorCode: ErrorCode.FileOperationFailed,
+          message: `Failed to copy file: ${msg}`,
+        });
+      }
+    }
+  }
+
+  async vaultCopy(req: express.Request, res: express.Response): Promise<void> {
+    const path = this.extractVaultPath(req, res);
+    if (path === null) return;
+    return this._vaultCopy(path, req, res);
+  }
+
   getPeriodicNoteInterface(): Record<string, PeriodicNoteInterface> {
     return this.operations.getPeriodicNoteInterface();
   }
@@ -1447,10 +1532,10 @@ export default class RequestHandler {
       next();
     });
     this.api.use(responseTime());
-    this.api.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE"] }));
+    this.api.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"] }));
 
     const mcpRouter = express.Router();
-    mcpRouter.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE"] }));
+    mcpRouter.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"] }));
     mcpRouter.use((req, res, next) => {
       if (!this.requestIsAuthenticated(req)) {
         this.returnCannedResponse(res, {
@@ -1519,6 +1604,8 @@ export default class RequestHandler {
       .all((req, res, next) => {
         if (req.method === "MOVE") {
           return this.handle((rq, rs) => this.vaultMove(rq, rs))(req, res, next);
+        } else if (req.method === "COPY") {
+          return this.handle((rq, rs) => this.vaultCopy(rq, rs))(req, res, next);
         } else {
           next();
         }

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -363,6 +363,48 @@ export class VaultOperations {
     return sourceFile.path;
   }
 
+  async copyVaultFile(
+    sourcePath: string,
+    destinationPath: string,
+    allowOverwrite = false,
+  ): Promise<string> {
+    if (!destinationPath) {
+      throw new Error("Destination path must not be empty.");
+    }
+
+    const sourceFile = this.app.vault.getAbstractFileByPath(sourcePath);
+    if (!(sourceFile instanceof TFile)) {
+      throw new FileNotFoundError(`File not found: ${sourcePath}`);
+    }
+
+    if (sourcePath === destinationPath) {
+      throw new DestinationAlreadyExistsError(
+        `Destination already exists: ${destinationPath}`,
+      );
+    }
+
+    const destExists = await this.app.vault.adapter.exists(destinationPath);
+    if (destExists) {
+      if (!allowOverwrite) {
+        throw new DestinationAlreadyExistsError(
+          `Destination already exists: ${destinationPath}`,
+        );
+      }
+      await this.app.vault.adapter.remove(destinationPath);
+    }
+
+    const parentDir = destinationPath.substring(
+      0,
+      destinationPath.lastIndexOf("/"),
+    );
+    if (parentDir && !(await this.app.vault.adapter.exists(parentDir))) {
+      await this.app.vault.createFolder(parentDir);
+    }
+
+    const copiedFile = await this.app.vault.copy(sourceFile, destinationPath);
+    return copiedFile.path;
+  }
+
   // Throws PatchFailed on patch error; caller is responsible for mapping to
   // the appropriate HTTP error code or MCP error.
   async patchFileSection(


### PR DESCRIPTION
## Summary
- Adds a `COPY` method on `/vault/{path}`, mirroring the existing `MOVE` implementation (`Destination`/`Allow-Overwrite` headers, trailing-slash destination semantics, path-traversal protection).
- Adds a matching `vault_copy` MCP tool.
- Uses Obsidian's public `Vault.copy()` API; bumps `minAppVersion` to `1.8.7` (required by that API).
- Unlike `MOVE`, the source file is left in place — not destructive to the source, but still marked `destructiveHint: true` on the MCP tool since it can overwrite an existing destination file (same rationale as `vault_write`).

Part of the 5.0 planning tracked in `Obsidian Local Rest API 5.0 Feature Ideas` (Accepted: "COPY, yes, just make it mirror MOVE.").

## Test plan
- [x] `npm test` (224 unit tests passing)
- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors introduced; pre-existing `main.ts` deprecation warnings unrelated to this change)
- [ ] `npm run test:integration` against a live Obsidian instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)