### PR TITLE
Move deleted files to trash by default instead of hard-deleting

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 | `vault_write` | Create or overwrite a vault file |
 | `vault_append` | Append content to the end of a vault file |
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
-| `vault_delete` | Delete a vault file |
+| `vault_delete` | Delete a vault file (moves to trash by default) |
 | `vault_move` | Move (rename) a vault file to a new path |
 | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
 | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -119,7 +119,18 @@ paths:
         - "System"
   /active/:
     delete:
-      parameters: []
+      parameters:
+        - description: |
+            If "true", the file is permanently deleted instead of being moved to trash. Defaults to "false", which moves the file to trash following the user's Obsidian "Deleted files" preference (either the ".trash" folder or the system trash).
+          in: "query"
+          name: "permanent"
+          required: false
+          schema:
+            default: "false"
+            enum:
+              - "true"
+              - "false"
+            type: "string"
       responses:
         "204":
           description: "Success"
@@ -1060,7 +1071,7 @@ paths:
         | `vault_write` | Create or overwrite a vault file |
         | `vault_append` | Append content to the end of a vault file |
         | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
-        | `vault_delete` | Delete a vault file |
+        | `vault_delete` | Delete a vault file (moves to trash by default) |
         | `vault_move` | Move (rename) a vault file to a new path |
         | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
         | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |
@@ -1245,6 +1256,17 @@ paths:
   "/periodic/{period}/":
     delete:
       parameters:
+        - description: |
+            If "true", the file is permanently deleted instead of being moved to trash. Defaults to "false", which moves the file to trash following the user's Obsidian "Deleted files" preference (either the ".trash" folder or the system trash).
+          in: "query"
+          name: "permanent"
+          required: false
+          schema:
+            default: "false"
+            enum:
+              - "true"
+              - "false"
+            type: "string"
         - description: "The name of the period for which you would like to grab a periodic note."
           in: "path"
           name: "period"
@@ -2141,6 +2163,17 @@ paths:
       description: |
         Deletes the periodic note for the specified period.
       parameters:
+        - description: |
+            If "true", the file is permanently deleted instead of being moved to trash. Defaults to "false", which moves the file to trash following the user's Obsidian "Deleted files" preference (either the ".trash" folder or the system trash).
+          in: "query"
+          name: "permanent"
+          required: false
+          schema:
+            default: "false"
+            enum:
+              - "true"
+              - "false"
+            type: "string"
         - description: "The year of the date for which you would like to grab a periodic note."
           in: "path"
           name: "year"
@@ -3421,6 +3454,17 @@ paths:
           - "Vault Files"
     delete:
       parameters:
+        - description: |
+            If "true", the file is permanently deleted instead of being moved to trash. Defaults to "false", which moves the file to trash following the user's Obsidian "Deleted files" preference (either the ".trash" folder or the system trash).
+          in: "query"
+          name: "permanent"
+          required: false
+          schema:
+            default: "false"
+            enum:
+              - "true"
+              - "false"
+            type: "string"
         - description: "Path to the relevant file (relative to your vault root).\n Optionally, you may include a reference to target a sub-part of the document; see \"Targeting a Sub-part of your Document\" for details."
           in: "path"
           name: "filename"

--- a/docs/src/lib/delete.jsonnet
+++ b/docs/src/lib/delete.jsonnet
@@ -1,5 +1,17 @@
 {
-  parameters: [],
+  parameters: [
+    {
+      name: 'permanent',
+      'in': 'query',
+      description: 'If "true", the file is permanently deleted instead of being moved to trash. Defaults to "false", which moves the file to trash following the user\'s Obsidian "Deleted files" preference (either the ".trash" folder or the system trash).\n',
+      required: false,
+      schema: {
+        type: 'string',
+        enum: ['true', 'false'],
+        default: 'false',
+      },
+    },
+  ],
   responses: {
     '204': {
       description: 'Success',

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -13,7 +13,7 @@ Include the `MCP-Protocol-Version` header on all requests after initialization, 
 | `vault_write` | Create or overwrite a vault file |
 | `vault_append` | Append content to the end of a vault file |
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
-| `vault_delete` | Delete a vault file |
+| `vault_delete` | Delete a vault file (moves to trash by default) |
 | `vault_move` | Move (rename) a vault file to a new path |
 | `vault_get_document_map` | List the headings, block references, and frontmatter fields in a file |
 | `active_file_get_path` | Return the vault path of the file currently open in Obsidian |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "obsidian-local-rest-api",
 	"name": "Local REST API with MCP",
 	"version": "4.1.7",
-	"minAppVersion": "1.4.0",
+	"minAppVersion": "1.6.6",
 	"description": "A secure REST API and Model Context Protocol (MCP) server for your vault.",
 	"author": "Adam Coddington",
 	"authorUrl": "https://adamcoddington.net/",

--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -98,6 +98,14 @@ export class Vault {
   }
 }
 
+class FileManager {
+  _trashFile: TFile | undefined;
+
+  async trashFile(file: TFile): Promise<void> {
+    this._trashFile = file;
+  }
+}
+
 export class Loc {
   line = -1;
 }
@@ -174,6 +182,7 @@ export class App {
   vault = new Vault();
   workspace = new Workspace();
   metadataCache = new MetadataCache();
+  fileManager = new FileManager();
   commands = {
     commands: {} as Record<string, Command>,
 

--- a/src/integration/vault.test.ts
+++ b/src/integration/vault.test.ts
@@ -458,6 +458,14 @@ describe("DELETE /vault/{file}", () => {
     const res = await unauthFetch(`/vault/${TEST_PATH}`, { method: "DELETE" });
     expect(res.status).toBe(401);
   });
+
+  test("?permanent=true hard-deletes the file", async () => {
+    const res = await authedFetch(`/vault/${TEST_PATH}?permanent=true`, { method: "DELETE" });
+    expect(res.status).toBe(204);
+
+    const getRes = await authedFetch(`/vault/${TEST_PATH}`);
+    expect(getRes.status).toBe(404);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -548,11 +548,17 @@ describe("McpHandler", () => {
 
   // ---- vault_delete -------------------------------------------------------
 
-  test("vault_delete calls deleteVaultFile and returns OK", async () => {
+  test("vault_delete calls deleteVaultFile and returns OK, defaulting to trash", async () => {
     const cb = getToolCallback("vault_delete");
     const result = await cb({ path: "old.md" });
-    expect(ops.deleteVaultFile).toHaveBeenCalledWith("old.md");
+    expect(ops.deleteVaultFile).toHaveBeenCalledWith("old.md", false);
     expect(parseText(result).message).toBe("OK");
+  });
+
+  test("vault_delete passes permanent flag through", async () => {
+    const cb = getToolCallback("vault_delete");
+    await cb({ path: "old.md", permanent: true });
+    expect(ops.deleteVaultFile).toHaveBeenCalledWith("old.md", true);
   });
 
   // ---- vault_move ---------------------------------------------------------

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -423,11 +423,19 @@ export class McpHandler {
 
     this.tool(
       "vault_delete",
-      "Delete a file from the vault. Throws if the file does not exist.",
-      { path: z.string().describe("File path relative to vault root") },
+      dedent`Delete a file from the vault. Throws if the file does not exist. By default, moves the file to trash (following the user's Obsidian "Deleted files" preference — either the ".trash" folder or the system trash) rather than deleting it permanently.`,
+      {
+        path: z.string().describe("File path relative to vault root"),
+        permanent: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, permanently deletes the file instead of moving it to trash (default: false).",
+          ),
+      },
       { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
-      async ({ path }: { path: string }) => {
-        await this.ops.deleteVaultFile(path);
+      async ({ path, permanent }: { path: string; permanent?: boolean }) => {
+        await this.ops.deleteVaultFile(path, permanent ?? false);
         return this.text({ message: "OK" });
       },
     );

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -600,20 +600,33 @@ describe("requestHandler", () => {
         .expect(405);
     });
 
-    test("non-existing file", async () => {
+    test("non-existing file with ?permanent=true", async () => {
       const arbitraryFilePath = "somefile.md";
       const arbitraryBytes = "bytes";
 
       app.vault.adapter._exists = false;
 
       await request(server)
-        .delete(`/vault/${arbitraryFilePath}`)
+        .delete(`/vault/${arbitraryFilePath}?permanent=true`)
         .set("Content-Type", "text/markdown")
         .set("Authorization", `Bearer ${API_KEY}`)
         .send(arbitraryBytes)
         .expect(404);
 
       expect(app.vault.adapter._remove).toBeUndefined();
+    });
+
+    test("non-existing file with default trash behavior", async () => {
+      const arbitraryFilePath = "somefile.md";
+
+      app.vault._getAbstractFileByPath = null;
+
+      await request(server)
+        .delete(`/vault/${arbitraryFilePath}`)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(404);
+
+      expect(app.fileManager._trashFile).toBeUndefined();
     });
 
     test("unauthorized", async () => {
@@ -627,18 +640,43 @@ describe("requestHandler", () => {
         .expect(401);
     });
 
-    test("existing file", async () => {
+    test("existing file moves to trash by default", async () => {
+      const arbitraryFilePath = "somefile.md";
+
+      await request(server)
+        .delete(`/vault/${arbitraryFilePath}`)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(204);
+
+      expect(app.fileManager._trashFile).toEqual(app.vault._getAbstractFileByPath);
+      expect(app.vault.adapter._remove).toBeUndefined();
+    });
+
+    test("existing file with ?permanent=true hard-deletes", async () => {
       const arbitraryFilePath = "somefile.md";
       const arbitraryBytes = "bytes";
 
       await request(server)
-        .delete(`/vault/${arbitraryFilePath}`)
+        .delete(`/vault/${arbitraryFilePath}?permanent=true`)
         .set("Content-Type", "text/markdown")
         .set("Authorization", `Bearer ${API_KEY}`)
         .send(arbitraryBytes)
         .expect(204);
 
       expect(app.vault.adapter._remove).toEqual([arbitraryFilePath]);
+      expect(app.fileManager._trashFile).toBeUndefined();
+    });
+
+    test("?permanent=false is equivalent to omitting the parameter", async () => {
+      const arbitraryFilePath = "somefile.md";
+
+      await request(server)
+        .delete(`/vault/${arbitraryFilePath}?permanent=false`)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .expect(204);
+
+      expect(app.fileManager._trashFile).toEqual(app.vault._getAbstractFileByPath);
+      expect(app.vault.adapter._remove).toBeUndefined();
     });
   });
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -744,7 +744,7 @@ export default class RequestHandler {
 
   async _vaultDelete(
     path: string,
-    _req: express.Request,
+    req: express.Request,
     res: express.Response,
   ): Promise<void> {
     if (!path || path.endsWith("/")) {
@@ -753,8 +753,9 @@ export default class RequestHandler {
       });
       return;
     }
+    const permanent = req.query.permanent === "true";
     try {
-      await this.operations.deleteVaultFile(path);
+      await this.operations.deleteVaultFile(path, permanent);
     } catch (e) {
       if (e instanceof FileNotFoundError) {
         this.returnCannedResponse(res, { statusCode: 404 });

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -314,12 +314,21 @@ export class VaultOperations {
     await this.app.vault.adapter.write(filePath, fileContents);
   }
 
-  async deleteVaultFile(filePath: string): Promise<void> {
-    const pathExists = await this.app.vault.adapter.exists(filePath);
-    if (!pathExists) {
+  async deleteVaultFile(filePath: string, permanent = false): Promise<void> {
+    if (permanent) {
+      const pathExists = await this.app.vault.adapter.exists(filePath);
+      if (!pathExists) {
+        throw new FileNotFoundError(`File not found: ${filePath}`);
+      }
+      await this.app.vault.adapter.remove(filePath);
+      return;
+    }
+
+    const file = this.app.vault.getAbstractFileByPath(filePath);
+    if (!file) {
       throw new FileNotFoundError(`File not found: ${filePath}`);
     }
-    await this.app.vault.adapter.remove(filePath);
+    await this.app.fileManager.trashFile(file);
   }
 
   async moveVaultFile(


### PR DESCRIPTION
## Summary
- `DELETE` on `/vault/{path}`, `/active/`, and `/periodic/...` now moves files to trash via `FileManager.trashFile()` by default, respecting the user's Obsidian "Deleted files" preference (`.trash/` folder or system trash), instead of permanently destroying the file via `adapter.remove()`.
- A new `?permanent=true` query parameter restores the old irrecoverable hard-delete behavior.
- MCP `vault_delete` gets a matching optional `permanent` boolean argument, defaulting to `false`.
- This is a change to default behavior, which is why it's targeted at the 5.0 major bump rather than a patch release.
- Uses `FileManager.trashFile()`, which bumps `minAppVersion` to `1.6.6`.

Part of the 5.0 planning tracked in `Obsidian Local Rest API 5.0 Feature Ideas` (Accepted: "Trash instead of hard delete is 100% a thing we should do... I like the API design you've proposed.").

## Test plan
- [x] `npm test` (208 unit tests passing)
- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors introduced; pre-existing `main.ts` deprecation warnings unrelated to this change)
- [ ] `npm run test:integration` against a live Obsidian instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)