### PR TITLE
Expose unresolvedLinks in document metadata

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -47,6 +47,11 @@ components:
           items:
             type: "string"
           type: "array"
+        unresolvedLinks:
+          description: "Link text found in this file that does not resolve to an existing vault file."
+          items:
+            type: "string"
+          type: "array"
       required:
         - "tags"
         - "frontmatter"
@@ -55,6 +60,7 @@ components:
         - "content"
         - "links"
         - "backlinks"
+        - "unresolvedLinks"
       type: "object"
   securitySchemes:
     apiKeyAuth:

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -87,6 +87,7 @@ std.manifestYamlDoc(
             'content',
             'links',
             'backlinks',
+            'unresolvedLinks',
           ],
           properties: {
             tags: {
@@ -133,6 +134,13 @@ std.manifestYamlDoc(
             backlinks: {
               type: 'array',
               description: 'Vault-relative paths of files that link to this file.',
+              items: {
+                type: 'string',
+              },
+            },
+            unresolvedLinks: {
+              type: 'array',
+              description: 'Link text found in this file that does not resolve to an existing vault file.',
               items: {
                 type: 'string',
               },

--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -123,6 +123,7 @@ export class MetadataCache {
   _getFileCache: CachedMetadata | null = new CachedMetadata();
   _listeners: Map<string, ((...data: unknown[]) => unknown)[]> = new Map();
   resolvedLinks: Record<string, Record<string, number>> = {};
+  unresolvedLinks: Record<string, Record<string, number>> = {};
 
   getFileCache(file: TFile): CachedMetadata | null {
     return this._getFileCache;

--- a/src/integration/vault.test.ts
+++ b/src/integration/vault.test.ts
@@ -107,6 +107,30 @@ describe("GET /vault/{file} with Accept: application/vnd.olrapi.note+json", () =
   });
 });
 
+describe("GET /vault/{file} with Accept: application/vnd.olrapi.note+json — unresolvedLinks", () => {
+  const LINKS_PATH = `${TEST_DIR}/unresolved-links-fixture.md`;
+
+  beforeEach(async () => {
+    await resetFixture("Links to [[xylophone-does-not-exist]].\n", LINKS_PATH);
+  });
+
+  afterEach(async () => {
+    await deleteFixture(LINKS_PATH);
+  });
+
+  test("includes links to non-existent files in unresolvedLinks", async () => {
+    const res = await authedFetch(`/vault/${LINKS_PATH}`, {
+      headers: { Accept: "application/vnd.olrapi.note+json" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.unresolvedLinks)).toBe(true);
+    expect(
+      body.unresolvedLinks.some((link: string) => link.includes("xylophone-does-not-exist")),
+    ).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Accept: application/vnd.olrapi.document-map+json
 // ---------------------------------------------------------------------------

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -77,6 +77,7 @@ function makeMockOps() {
       path: mockFile.path,
       links: [],
       backlinks: [],
+      unresolvedLinks: [],
     }),
     getDocumentMapObject: jest.fn().mockResolvedValue({
       headings: ["Alpha", "Alpha::Subsection"],

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -230,7 +230,7 @@ export class McpHandler {
     this.tool(
       "vault_read",
       dedent`
-        Read a vault file's content and metadata. Returns a JSON object with: content (full markdown text), path, tags (array of tag strings), frontmatter (parsed YAML front-matter as an object), stat ({ctime, mtime, size}), links (array of vault-relative paths this file links to), and backlinks (array of vault-relative paths of files that link here). Throws if the file does not exist.
+        Read a vault file's content and metadata. Returns a JSON object with: content (full markdown text), path, tags (array of tag strings), frontmatter (parsed YAML front-matter as an object), stat ({ctime, mtime, size}), links (array of vault-relative paths this file links to), backlinks (array of vault-relative paths of files that link here), and unresolvedLinks (array of link text in this file that does not resolve to an existing vault file). Throws if the file does not exist.
 
         When targetType and target are both provided, returns only the matched section as a plain string (markdown) or JSON value (frontmatter) instead of the full object. To save context, call vault_get_document_map first to identify headings, block IDs, or frontmatter keys, and prefer targeted reads over full reads for anything but short files.
       `,
@@ -608,7 +608,8 @@ export class McpHandler {
           "frontmatter": { "status": "done", "url": "https://example.com", "priority": 2 },
           "stat": { "ctime": 1705276800000, "mtime": 1705363200000, "size": 1024 },
           "links": ["projects/foo.md"],
-          "backlinks": ["index.md"]
+          "backlinks": ["index.md"],
+          "unresolvedLinks": ["not-yet-created.md"]
         }
 
         Call vault_read on any file (without targeting) to see the exact shape for a real file in this vault, including its actual frontmatter fields.

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -214,6 +214,28 @@ describe("requestHandler", () => {
         .set("Authorization", `Bearer ${API_KEY}`)
         .expect(404);
     });
+
+    test("Accept: application/vnd.olrapi.note+json includes links, backlinks, and unresolvedLinks", async () => {
+      const targetPath = app.vault._getAbstractFileByPath.path;
+
+      app.metadataCache.resolvedLinks = {
+        [targetPath]: { "resolved-target.md": 1 },
+        "other.md": { [targetPath]: 1 },
+      };
+      app.metadataCache.unresolvedLinks = {
+        [targetPath]: { "not-yet-created.md": 1 },
+      };
+
+      const result = await request(server)
+        .get(`/vault/${targetPath}`)
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Accept", "application/vnd.olrapi.note+json")
+        .expect(200);
+
+      expect(result.body.links).toEqual(["resolved-target.md"]);
+      expect(result.body.backlinks).toEqual(["other.md"]);
+      expect(result.body.unresolvedLinks).toEqual(["not-yet-created.md"]);
+    });
   });
 
   describe("vaultGet section retrieval", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,7 @@ export interface FileMetadataObject {
   content: string;
   links: string[];
   backlinks: string[];
+  unresolvedLinks: string[];
 }
 
 export interface DocumentMapObject {

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -186,6 +186,9 @@ export class VaultOperations {
     const links = Object.keys(
       this.app.metadataCache.resolvedLinks[file.path] ?? {},
     );
+    const unresolvedLinks = Object.keys(
+      this.app.metadataCache.unresolvedLinks[file.path] ?? {},
+    );
 
     const index = backlinksIndex ?? this.buildBacklinksIndex();
     const backlinks = index[file.path] ?? [];
@@ -198,6 +201,7 @@ export class VaultOperations {
       content: includeContent ? await this.app.vault.cachedRead(file) : "",
       links,
       backlinks,
+      unresolvedLinks,
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds an `unresolvedLinks` field to `NoteJson`, sourced from Obsidian's `metadataCache.unresolvedLinks` (link text found in a file that does not resolve to an existing vault file).
- Surfaced via `GET` with `Accept: application/vnd.olrapi.note+json`, the `vault_read` MCP tool, and the `search_query` JsonLogic evaluation context (since `searchJsonLogic` already builds its per-file context from `getFileMetadataObject`, no extra work was needed there).

This is a narrower slice of the "links, holistically" discussion still under consideration in `Obsidian Local Rest API 5.0 Feature Ideas` — the doc calls out `unresolvedLinks` specifically as something worth shipping now regardless of that broader discussion ("we should at least begin exposing unresolvedLinks as part of the document metadata").

## Test plan
- [x] `npm test` (225 unit tests passing)
- [x] `npm run typecheck` (including `tsconfig.integration.json`)
- [x] `npm run lint` (no new errors introduced; pre-existing `main.ts` deprecation warnings unrelated to this change)
- [ ] `npm run test:integration` against a live Obsidian instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)