### PR TITLE
Reject Target-Scope other than 'content' for frontmatter targets

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -535,7 +535,9 @@ paths:
             type: "string"
         - description: |
             Controls which part of the target the operation acts on. Only applicable to
-            `heading` and `block` targets; ignored for `frontmatter`.
+            `heading` and `block` targets. Combining a `Target-Scope` other than `content`
+            with `Target-Type: frontmatter` returns a 400 error, since a frontmatter field
+            has no marker/content distinction.
             
             - `content` (default): the operation applies to the content region only — the area
               below the heading line or at the block, leaving the heading/block-ID token unchanged.
@@ -1711,7 +1713,9 @@ paths:
             type: "string"
         - description: |
             Controls which part of the target the operation acts on. Only applicable to
-            `heading` and `block` targets; ignored for `frontmatter`.
+            `heading` and `block` targets. Combining a `Target-Scope` other than `content`
+            with `Target-Type: frontmatter` returns a 400 error, since a frontmatter field
+            has no marker/content distinction.
             
             - `content` (default): the operation applies to the content region only — the area
               below the heading line or at the block, leaving the heading/block-ID token unchanged.
@@ -2672,7 +2676,9 @@ paths:
             type: "string"
         - description: |
             Controls which part of the target the operation acts on. Only applicable to
-            `heading` and `block` targets; ignored for `frontmatter`.
+            `heading` and `block` targets. Combining a `Target-Scope` other than `content`
+            with `Target-Type: frontmatter` returns a 400 error, since a frontmatter field
+            has no marker/content distinction.
             
             - `content` (default): the operation applies to the content region only — the area
               below the heading line or at the block, leaving the heading/block-ID token unchanged.
@@ -3947,7 +3953,9 @@ paths:
             type: "string"
         - description: |
             Controls which part of the target the operation acts on. Only applicable to
-            `heading` and `block` targets; ignored for `frontmatter`.
+            `heading` and `block` targets. Combining a `Target-Scope` other than `content`
+            with `Target-Type: frontmatter` returns a 400 error, since a frontmatter field
+            has no marker/content distinction.
             
             - `content` (default): the operation applies to the content region only — the area
               below the heading line or at the block, leaving the heading/block-ID token unchanged.

--- a/docs/src/lib/targeting.params.jsonnet
+++ b/docs/src/lib/targeting.params.jsonnet
@@ -93,7 +93,9 @@
     'in': 'header',
     description: |||
       Controls which part of the target the operation acts on. Only applicable to
-      `heading` and `block` targets; ignored for `frontmatter`.
+      `heading` and `block` targets. Combining a `Target-Scope` other than `content`
+      with `Target-Type: frontmatter` returns a 400 error, since a frontmatter field
+      has no marker/content distinction.
 
       - `content` (default): the operation applies to the content region only — the area
         below the heading line or at the block, leaving the heading/block-ID token unchanged.

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -423,6 +423,44 @@ describe("McpHandler", () => {
     );
   });
 
+  test("vault_patch rejects targetType frontmatter combined with a non-content targetScope", async () => {
+    const cb = getToolCallback("vault_patch");
+    await expect(
+      cb({
+        path: "out.md",
+        targetType: "frontmatter",
+        target: "title",
+        operation: "replace",
+        content: '"New Title"',
+        contentType: "application/json",
+        targetScope: "marker",
+      }),
+    ).rejects.toThrow(/targetScope/);
+    expect(ops.patchFileSection).not.toHaveBeenCalled();
+  });
+
+  test("vault_patch allows targetType frontmatter with targetScope content", async () => {
+    const cb = getToolCallback("vault_patch");
+    await cb({
+      path: "out.md",
+      targetType: "frontmatter",
+      target: "title",
+      operation: "replace",
+      content: '"New Title"',
+      contentType: "application/json",
+      targetScope: "content",
+    });
+    expect(ops.patchFileSection).toHaveBeenCalledWith(
+      "out.md",
+      "frontmatter",
+      "title",
+      "replace",
+      "New Title",
+      "application/json",
+      expect.objectContaining({ targetScope: "content" }),
+    );
+  });
+
   test("vault_patch surfaces PatchFailed message as error", async () => {
     const cb = getToolCallback("vault_patch");
     const err = new PatchFailed(PatchFailureReason.InvalidTarget, { targetType: "heading", target: ["NoSuch"], operation: "append", content: "x" } as any, null);

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -356,7 +356,7 @@ export class McpHandler {
           .enum(["content", "marker", "markerAndContent"])
           .optional()
           .describe(
-            dedent`Controls which part of the target the operation acts on. 'content' (default): the section content only. 'marker': just the heading line or block-ID token. 'markerAndContent': both together. Only applies to heading and block targets. IMPORTANT — a marker spans more than its visible label: for a heading, the leading '#' characters through the end of the line, including the newline; for a block reference, '^' (plus any preceding whitespace if inline) through the id, including the newline. Replacing 'marker' or 'markerAndContent' replaces that whole span, so match it: the same number of leading '#' as the original (count = targetDelimiter-separated segments in target, e.g. 'Heading 1::Subheading' → '##') or the heading is demoted to plain text; and a trailing newline, or the next line gets glued onto yours.`,
+            dedent`Controls which part of the target the operation acts on. 'content' (default): the section content only. 'marker': just the heading line or block-ID token. 'markerAndContent': both together. Only applies to heading and block targets — combining a non-'content' value with targetType 'frontmatter' returns an error, since a frontmatter field has no marker/content distinction. IMPORTANT — a marker spans more than its visible label: for a heading, the leading '#' characters through the end of the line, including the newline; for a block reference, '^' (plus any preceding whitespace if inline) through the id, including the newline. Replacing 'marker' or 'markerAndContent' replaces that whole span, so match it: the same number of leading '#' as the original (count = targetDelimiter-separated segments in target, e.g. 'Heading 1::Subheading' → '##') or the heading is demoted to plain text; and a trailing newline, or the next line gets glued onto yours.`,
           ),
       },
       { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
@@ -385,6 +385,11 @@ export class McpHandler {
         targetDelimiter?: string;
         targetScope?: "content" | "marker" | "markerAndContent";
       }) => {
+        if (targetType === "frontmatter" && targetScope && targetScope !== "content") {
+          throw new Error(
+            "targetScope must be 'content' (or omitted) when targetType is 'frontmatter' -- a frontmatter field has no marker/content distinction.",
+          );
+        }
         try {
           // MCP transport delivers all parameters as strings; parse JSON content
           // here so downstream code receives a native value, not a serialized string.

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -1074,6 +1074,60 @@ describe("requestHandler", () => {
       expect(res.body.errorCode).toBe(40005);
     });
 
+    test("Target-Type: frontmatter with Target-Scope: marker returns 400 with errorCode 40059", async () => {
+      const res = await request(server)
+        .patch("/vault/somefile.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Target-Type", "frontmatter")
+        .set("Target", "title")
+        .set("Target-Scope", "marker")
+        .set("Operation", "replace")
+        .send("new value");
+      expect(res.status).toBe(400);
+      expect(res.body.errorCode).toBe(40059);
+    });
+
+    test("Target-Type: frontmatter with Target-Scope: markerAndContent returns 400 with errorCode 40059", async () => {
+      const res = await request(server)
+        .patch("/vault/somefile.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Target-Type", "frontmatter")
+        .set("Target", "title")
+        .set("Target-Scope", "markerAndContent")
+        .set("Operation", "replace")
+        .send("new value");
+      expect(res.status).toBe(400);
+      expect(res.body.errorCode).toBe(40059);
+    });
+
+    test("Target-Type: frontmatter with Target-Scope: content is accepted", async () => {
+      jest.spyOn(handler.operations, "patchFileSection").mockResolvedValueOnce("patched");
+      const res = await request(server)
+        .patch("/vault/somefile.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Content-Type", "application/json")
+        .set("Target-Type", "frontmatter")
+        .set("Target", "title")
+        .set("Target-Scope", "content")
+        .set("Operation", "replace")
+        .send('"new value"');
+      expect(res.status).toBe(200);
+    });
+
+    test("Target-Type: heading with Target-Scope: marker is accepted", async () => {
+      jest.spyOn(handler.operations, "patchFileSection").mockResolvedValueOnce("patched");
+      const res = await request(server)
+        .patch("/vault/somefile.md")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Content-Type", "text/markdown")
+        .set("Target-Type", "heading")
+        .set("Target", "Heading1")
+        .set("Target-Scope", "marker")
+        .set("Operation", "replace")
+        .send("## New Heading");
+      expect(res.status).toBe(200);
+    });
+
   });
 
   describe("path traversal prevention", () => {
@@ -1378,6 +1432,17 @@ describe("requestHandler", () => {
           .set("Target-Type", "heading")
           .send("content")
           .expect(422);
+      });
+
+      test("frontmatter URL target with Target-Scope: marker returns 400 with errorCode 40059", async () => {
+        const res = await request(server)
+          .put("/vault/somefile.md/frontmatter/title")
+          .set("Authorization", `Bearer ${API_KEY}`)
+          .set("Content-Type", "application/json")
+          .set("Target-Scope", "marker")
+          .send('"New Title"');
+        expect(res.status).toBe(400);
+        expect(res.body.errorCode).toBe(40059);
       });
     });
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -590,6 +590,10 @@ export default class RequestHandler {
       this.returnCannedResponse(res, { errorCode: ErrorCode.InvalidTargetScopeHeader });
       return;
     }
+    if (targetType === "frontmatter" && targetScope && targetScope !== "content") {
+      this.returnCannedResponse(res, { errorCode: ErrorCode.InvalidTargetScopeHeader });
+      return;
+    }
     if (!isContentType(contentType)) {
       this.returnCannedResponse(res, { errorCode: ErrorCode.InvalidContentType });
       return;
@@ -649,6 +653,10 @@ export default class RequestHandler {
       return;
     }
     if (targetScope && !isPatchTargetScope(targetScope)) {
+      this.returnCannedResponse(res, { errorCode: ErrorCode.InvalidTargetScopeHeader });
+      return;
+    }
+    if (targetType === "frontmatter" && targetScope && targetScope !== "content") {
       this.returnCannedResponse(res, { errorCode: ErrorCode.InvalidTargetScopeHeader });
       return;
     }


### PR DESCRIPTION
## Summary

Came out of reviewing #306 (rendered HTML reads): we decided `Target-Type: frontmatter` should reject an HTML render since frontmatter has no HTML rendering, which raised the same question for `Target-Scope`. `Target-Scope` (`content`/`marker`/`markerAndContent`) only has meaning for `heading`/`block` targets — a marker is the heading line or block-ID token, and frontmatter fields have no such thing. Today, `markdown-patch`'s frontmatter branch silently ignores `Target-Scope` entirely rather than rejecting the combination, even though it's already documented as not applicable.

This validates that combination and returns 400 (`errorCode` 40059, `InvalidTargetScopeHeader`) instead of silently ignoring it.

- `src/requestHandler.ts`: added the check to both `_vaultPatch` (direct `PATCH`) and `_vaultPatchTargeted` (the shared implementation behind `PUT`/`POST` with a URL-embedded target, as well as active-file and periodic-note PATCH-style endpoints).
- `src/mcpHandler.ts`: the `vault_patch` MCP tool calls `patchFileSection` directly rather than going through `requestHandler.ts`, so it needed its own copy of the check to keep REST/MCP behavior in sync.
- `docs/src/lib/targeting.params.jsonnet`: updated the shared `Target-Scope` description from "ignored for frontmatter" to describe the 400.
- `docs/openapi.yaml`: regenerated.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (236 passing, including new failing-then-passing tests per TDD: `Target-Type: frontmatter` + `Target-Scope: marker`/`markerAndContent` → 400/40059 for both the direct PATCH path and the PUT-via-URL-target path, plus sanity checks that `Target-Scope: content` and heading+marker combinations are still accepted)
- [x] New MCP-side tests confirming `vault_patch` rejects the same combination and still allows `targetScope: "content"` with `targetType: "frontmatter"`
- [ ] `npm run test:integration` — not run; no live Obsidian instance available in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)