### PR TITLE
Fix slash-containing date formats and make periodic note periods always available

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Access your vault through the **REST API** or the **built-in [MCP server](https:
 - **Surgically patch specific sections** — target a heading, block reference, or frontmatter key and append, prepend, replace, delete, or move just that section without touching the rest of the file
 - **Search your vault** — simple full-text search or structured [JsonLogic](https://jsonlogic.com/) queries against note metadata (frontmatter, tags, path, content)
 - **Access the active file** — read or write whatever note is currently open in Obsidian
-- **Work with periodic notes** — get or create daily, weekly, monthly, quarterly, and yearly notes
+- **Work with periodic notes** — get or create daily, weekly, monthly, quarterly, and yearly notes; each period's folder, filename format, and template are configurable in the plugin's settings, with sensible defaults out of the box
 - **List and execute commands** — trigger any Obsidian command as if you'd used the command palette
 - **Query tags** — list all tags across your vault with usage counts
 - **Open files in Obsidian** — tell Obsidian to open a specific note in its UI

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1662,6 +1662,8 @@ paths:
       description: |
         Returns the content of the current periodic note for the specified period.
         
+        Every period is always available. Each period's folder, filename date format, and creation template are configurable in the plugin's "Periodic Notes" settings section; an unconfigured period uses sensible defaults (notes at the vault root, with a standard format such as `YYYY-MM-DD` for daily notes).
+        
         # Targeting a Sub-part of your Document
         
         You can operate on a specific section of a note instead of the whole file by embedding a target in the URL path, immediately after the note identifier. The first segment after the note is the target type, and the remaining segments address the target:
@@ -2792,6 +2794,8 @@ paths:
     get:
       description: |
         Returns the content of the periodic note for the specified period and date.
+        
+        Every period is always available. Each period's folder, filename date format, and creation template are configurable in the plugin's "Periodic Notes" settings section; an unconfigured period uses sensible defaults (notes at the vault root, with a standard format such as `YYYY-MM-DD` for daily notes).
         
         # Targeting a Sub-part of your Document
         

--- a/docs/src/lib/descriptions/periodic-current-get.md
+++ b/docs/src/lib/descriptions/periodic-current-get.md
@@ -1,1 +1,3 @@
 Returns the content of the current periodic note for the specified period.
+
+Every period is always available. Each period's folder, filename date format, and creation template are configurable in the plugin's "Periodic Notes" settings section; an unconfigured period uses sensible defaults (notes at the vault root, with a standard format such as `YYYY-MM-DD` for daily notes).

--- a/docs/src/lib/descriptions/periodic-date-get.md
+++ b/docs/src/lib/descriptions/periodic-date-get.md
@@ -1,1 +1,3 @@
 Returns the content of the periodic note for the specified period and date.
+
+Every period is always available. Each period's folder, filename date format, and creation template are configurable in the plugin's "Periodic Notes" settings section; an unconfigured period uses sensible defaults (notes at the vault root, with a standard format such as `YYYY-MM-DD` for daily notes).

--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -73,6 +73,7 @@ export class Vault {
   _files: TFile[] = [new TFile()];
   _markdownFiles: TFile[] = [];
   _create: [string, string] | undefined;
+  _createdFolders: string[] = [];
 
   adapter = new DataAdapter();
 
@@ -84,7 +85,9 @@ export class Vault {
     return this._cachedRead;
   }
 
-  async createFolder(path: string): Promise<void> {}
+  async createFolder(path: string): Promise<void> {
+    this._createdFolders.push(path);
+  }
 
   getFiles(): TFile[] {
     return this._files;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,6 @@ export const ERROR_CODE_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.InvalidContentForContentType]:
     "Your request body could not be processed as the content-type specified in your Content-Type header.",
   [ErrorCode.PeriodDoesNotExist]: "Specified period does not exist.",
-  [ErrorCode.PeriodIsNotEnabled]: "Specified period is not enabled.",
   [ErrorCode.PeriodicNoteDoesNotExist]:
     "Periodic note does not exist for the specified period.",
   [ErrorCode.RequestMethodValidOnlyForFiles]:

--- a/src/integration/periodic.test.ts
+++ b/src/integration/periodic.test.ts
@@ -32,18 +32,6 @@ describe("GET /periodic/daily", () => {
   });
 });
 
-describe("GET /periodic/daily — plugin not enabled", () => {
-  // Only run when OBSIDIAN_PERIODIC_NOTES=false is explicitly set
-  const pluginDisabledTest = process.env.OBSIDIAN_PERIODIC_NOTES === "false" ? test : test.skip;
-
-  pluginDisabledTest("returns 400 with errorCode 40060 when period is not enabled", async () => {
-    const res = await authedFetch("/periodic/daily/");
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.errorCode).toBe(40060);
-  });
-});
-
 describe("PUT /periodic/daily", () => {
   maybeTest("creates or replaces today's daily note and returns 200 or 204", async () => {
     const res = await authedFetch("/periodic/daily/", {

--- a/src/main.ts
+++ b/src/main.ts
@@ -326,17 +326,12 @@ class LocalRestApiSettingTab extends PluginSettingTab {
 
   private getPeriodicNoteDisplayValue(period: PeriodicNotePeriod): string {
     const settings = this.getPeriodicNoteSettings(period);
-    if (!settings.enabled) return "Disabled";
-    return settings.folder ? `Enabled — ${settings.folder}/` : "Enabled — vault root";
+    const location = settings.folder ? `${settings.folder}/` : "Vault root";
+    return `${location} · ${settings.format || PERIOD_DEFAULT_FORMAT[period]}`;
   }
 
   private getPeriodicNoteSettingDefinitions(period: PeriodicNotePeriod): SettingDefinitionItem[] {
     return [
-      {
-        name: "Enable",
-        desc: `Create and manage ${period} notes via this plugin's periodic note endpoints and MCP tool.`,
-        control: { type: "toggle", key: `periodicNotes:${period}:enabled` },
-      },
       {
         name: "Folder",
         desc: "Folder in which new notes are created. Leave blank for the vault root.",

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -877,8 +877,8 @@ describe("McpHandler", () => {
       expect(parseText(result).path).toBe("test.md");
     });
 
-    test("throws when the period is not enabled", async () => {
-      ops.periodicGetOrCreateNote.mockResolvedValue([null, ErrorCode.PeriodIsNotEnabled]);
+    test("throws when the periodic note cannot be resolved", async () => {
+      ops.periodicGetOrCreateNote.mockResolvedValue([null, ErrorCode.PeriodDoesNotExist]);
       const cb = getToolCallback("periodic_note_get_path");
       await expect(cb({ period: "weekly" })).rejects.toThrow(
         "Could not get or create periodic note",

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -574,7 +574,7 @@ export class McpHandler {
 
     this.tool(
       "periodic_note_get_path",
-      dedent`Return the vault-relative path of the current periodic note for the given period (daily, weekly, monthly, quarterly, or yearly). Creates the note file if it does not already exist, applying any configured template. Requires that period to be enabled under this plugin's "Periodic Notes" settings section. Use the returned path with vault_read, vault_write, vault_append, vault_patch, or vault_get_document_map to operate on the note.`,
+      dedent`Return the vault-relative path of the current periodic note for the given period (daily, weekly, monthly, quarterly, or yearly). Creates the note file if it does not already exist, applying any configured template. Every period is always available; its folder, filename format, and template can be configured under this plugin's "Periodic Notes" settings section, with sensible per-period defaults otherwise. Use the returned path with vault_read, vault_write, vault_append, vault_patch, or vault_get_document_map to operate on the note.`,
       {
         period: z
           .enum(PERIODS)

--- a/src/periodicNotes.test.ts
+++ b/src/periodicNotes.test.ts
@@ -90,6 +90,43 @@ describe("buildPeriodicNoteInterface", () => {
       const iface = buildPeriodicNoteInterface(app, "daily", settings({ format: "YYYY-MM-DD" }));
       expect(iface.getAll()).toEqual({});
     });
+
+    test("a format containing '/' matches notes nested in format-derived subfolders", () => {
+      // Core Daily Notes supports formats like YYYY/MM/YYYY-MM-DD, where the
+      // formatted filename itself spans subfolders under the configured folder.
+      const nested = new TFile();
+      nested.path = "journal/2024/01/2024-01-15.md";
+      nested.basename = "2024-01-15";
+      const decoy = new TFile();
+      decoy.path = "journal/2024/01/notes.md";
+      decoy.basename = "notes";
+      app.vault._markdownFiles = [nested, decoy];
+
+      const iface = buildPeriodicNoteInterface(
+        app,
+        "daily",
+        settings({ folder: "journal", format: "YYYY/MM/YYYY-MM-DD" }),
+      );
+      const all = iface.getAll();
+      expect(Object.keys(all)).toEqual(["2024/01/2024-01-15"]);
+
+      const found = iface.get(window.moment("2024-01-15", "YYYY-MM-DD"), all);
+      expect(found).toBe(nested);
+    });
+
+    test("a format containing '/' works with no folder configured", () => {
+      const nested = new TFile();
+      nested.path = "2024/01/2024-01-15.md";
+      nested.basename = "2024-01-15";
+      app.vault._markdownFiles = [nested];
+
+      const iface = buildPeriodicNoteInterface(
+        app,
+        "daily",
+        settings({ format: "YYYY/MM/YYYY-MM-DD" }),
+      );
+      expect(Object.keys(iface.getAll())).toEqual(["2024/01/2024-01-15"]);
+    });
   });
 
   describe("create", () => {
@@ -128,6 +165,36 @@ describe("buildPeriodicNoteInterface", () => {
       expect(content).toContain("# 2024-01-15");
       expect(content).toContain("Date: 2024-01-15");
       expect(content).toContain("Time: 09:30");
+    });
+
+    test("a format containing '/' creates the full parent folder chain", async () => {
+      // Previously only the configured base folder was ensured, so a
+      // format-derived subfolder path (e.g. YYYY/MM/…) made vault.create fail.
+      app.vault._getAbstractFileByPath = null; // nothing exists yet
+      const iface = buildPeriodicNoteInterface(
+        app,
+        "daily",
+        settings({ folder: "journal", format: "YYYY/MM/YYYY-MM-DD" }),
+      );
+      const date = window.moment("2024-01-15", "YYYY-MM-DD");
+      await iface.create(date);
+
+      expect(app.vault._createdFolders).toEqual(["journal/2024/01"]);
+      expect(app.vault._create?.[0]).toBe("journal/2024/01/2024-01-15.md");
+    });
+
+    test("a format containing '/' creates parent folders even with no folder configured", async () => {
+      app.vault._getAbstractFileByPath = null;
+      const iface = buildPeriodicNoteInterface(
+        app,
+        "daily",
+        settings({ format: "YYYY/MM/YYYY-MM-DD" }),
+      );
+      const date = window.moment("2024-01-15", "YYYY-MM-DD");
+      await iface.create(date);
+
+      expect(app.vault._createdFolders).toEqual(["2024/01"]);
+      expect(app.vault._create?.[0]).toBe("2024/01/2024-01-15.md");
     });
 
     test("creates an empty note when the configured template file cannot be found", async () => {

--- a/src/periodicNotes.test.ts
+++ b/src/periodicNotes.test.ts
@@ -14,7 +14,6 @@ describe("buildPeriodicNoteInterface", () => {
 
   function settings(overrides: Partial<PeriodicNotePeriodSettings> = {}): PeriodicNotePeriodSettings {
     return {
-      enabled: true,
       folder: "",
       format: "YYYY-MM-DD",
       template: "",
@@ -22,15 +21,19 @@ describe("buildPeriodicNoteInterface", () => {
     };
   }
 
-  test("loaded reflects the enabled flag", () => {
-    expect(buildPeriodicNoteInterface(app, "daily", settings({ enabled: true })).loaded).toBe(true);
-    expect(buildPeriodicNoteInterface(app, "daily", settings({ enabled: false })).loaded).toBe(false);
+  test("defaults are used when settings are undefined", () => {
+    const iface = buildPeriodicNoteInterface(app, "daily", undefined);
+    expect(iface.settings.format).toBe("YYYY-MM-DD");
+    expect(iface.settings.folder).toBe("");
+    expect(iface.settings.template).toBe("");
   });
 
-  test("loaded is false and defaults are used when settings are undefined", () => {
-    const iface = buildPeriodicNoteInterface(app, "daily", undefined);
-    expect(iface.loaded).toBe(false);
-    expect(iface.settings.format).toBe("YYYY-MM-DD");
+  test("each period falls back to its own default format when unconfigured", () => {
+    expect(buildPeriodicNoteInterface(app, "daily", undefined).settings.format).toBe("YYYY-MM-DD");
+    expect(buildPeriodicNoteInterface(app, "weekly", undefined).settings.format).toBe("gggg-[W]ww");
+    expect(buildPeriodicNoteInterface(app, "monthly", undefined).settings.format).toBe("YYYY-MM");
+    expect(buildPeriodicNoteInterface(app, "quarterly", undefined).settings.format).toBe("YYYY-[Q]Q");
+    expect(buildPeriodicNoteInterface(app, "yearly", undefined).settings.format).toBe("YYYY");
   });
 
   test("falls back to the period's default format when format is blank", () => {
@@ -231,7 +234,6 @@ describe("seedPeriodicNoteSettingsFromExistingPlugins", () => {
 
     const seeded = seedPeriodicNoteSettingsFromExistingPlugins(app);
     expect(seeded.daily).toEqual({
-      enabled: true,
       folder: "daily",
       format: "YYYY-MM-DD",
       template: "",
@@ -288,8 +290,8 @@ describe("seedPeriodicNoteSettingsFromExistingPlugins", () => {
     };
 
     const seeded = seedPeriodicNoteSettingsFromExistingPlugins(app);
-    expect(seeded.weekly).toEqual({ enabled: true, folder: "weekly", format: "gggg-[W]ww", template: "" });
-    expect(seeded.monthly).toEqual({ enabled: true, folder: "monthly", format: "YYYY-MM", template: "" });
+    expect(seeded.weekly).toEqual({ folder: "weekly", format: "gggg-[W]ww", template: "" });
+    expect(seeded.monthly).toEqual({ folder: "monthly", format: "YYYY-MM", template: "" });
     expect(seeded.quarterly).toBeUndefined();
     expect(seeded.yearly).toBeUndefined();
   });

--- a/src/periodicNotes.ts
+++ b/src/periodicNotes.ts
@@ -16,7 +16,6 @@ export const PERIOD_DEFAULT_FORMAT: Record<PeriodicNotePeriod, string> = {
 };
 
 export const DEFAULT_PERIODIC_NOTE_SETTINGS: PeriodicNotePeriodSettings = {
-  enabled: false,
   folder: "",
   format: "",
   template: "",
@@ -76,7 +75,6 @@ export function buildPeriodicNoteInterface(
 
   return {
     settings: { folder, format, template },
-    loaded: settings?.enabled ?? false,
     getAll,
     get: (date: Moment, all: Record<string, TFile>) => all[date.format(format)],
     create: async (date: Moment): Promise<TFile> => {
@@ -118,7 +116,6 @@ type RawPeriodSettings = {
 
 function toPeriodicNotePeriodSettings(raw: RawPeriodSettings): PeriodicNotePeriodSettings {
   return {
-    enabled: raw.enabled ?? false,
     folder: raw.folder?.trim() ?? "",
     format: raw.format?.trim() ?? "",
     template: raw.template?.trim() ?? "",
@@ -130,10 +127,10 @@ function toPeriodicNotePeriodSettings(raw: RawPeriodSettings): PeriodicNotePerio
  * Notes (community) plugin configuration into our own native settings, so
  * upgrading users don't lose their periodic-note configuration. Reads
  * undocumented plugin internals defensively — any unexpected shape is
- * skipped rather than thrown, leaving that period unseeded (disabled by
- * default) rather than risk seeding a bad value. Runs at most once per
- * vault (callers should only invoke this when `settings.periodicNotes` is
- * not yet set).
+ * skipped rather than thrown, leaving that period unseeded (falling back
+ * to the built-in defaults) rather than risk seeding a bad value. Runs at
+ * most once per vault (callers should only invoke this when
+ * `settings.periodicNotes` is not yet set).
  *
  * Known gap: weekly notes configured only via the legacy "Calendar" plugin
  * (not the "Periodic Notes" plugin) are not migrated — reading a third
@@ -162,7 +159,7 @@ export function seedPeriodicNoteSettingsFromExistingPlugins(
         | RawPeriodSettings
         | undefined;
       if (options) {
-        seeded.daily = toPeriodicNotePeriodSettings({ ...options, enabled: true });
+        seeded.daily = toPeriodicNotePeriodSettings(options);
       }
     }
   } catch (e) {

--- a/src/periodicNotes.ts
+++ b/src/periodicNotes.ts
@@ -44,16 +44,30 @@ export function buildPeriodicNoteInterface(
   const template = settings?.template?.trim() ?? "";
   const folderPath = folder ? normalizePath(folder) : "";
 
+  // A format may itself contain "/" (e.g. YYYY/MM/YYYY-MM-DD), in which case
+  // the formatted filename spans subfolders and must be matched against the
+  // file's folder-relative path rather than its basename.
+  const formatSpansFolders = format.includes("/");
+
   const getAll = (): Record<string, TFile> => {
     const notes: Record<string, TFile> = {};
     const folderPrefix = folderPath ? `${folderPath}/` : "";
     for (const file of app.vault.getMarkdownFiles()) {
-      if (folderPrefix) {
-        if (!file.path.startsWith(folderPrefix)) continue;
-      } else if (file.path.includes("/")) {
-        continue;
+      let candidate: string;
+      if (formatSpansFolders) {
+        if (folderPrefix && !file.path.startsWith(folderPrefix)) continue;
+        candidate = file.path
+          .slice(folderPrefix.length)
+          .replace(/\.md$/, "");
+      } else {
+        if (folderPrefix) {
+          if (!file.path.startsWith(folderPrefix)) continue;
+        } else if (file.path.includes("/")) {
+          continue;
+        }
+        candidate = file.basename;
       }
-      const parsed = window.moment(file.basename, format, true);
+      const parsed = window.moment(candidate, format, true);
       if (!parsed.isValid()) continue;
       notes[parsed.format(format)] = file;
     }
@@ -71,8 +85,12 @@ export function buildPeriodicNoteInterface(
         `${folderPath ? folderPath + "/" : ""}${filename}.md`,
       );
 
-      if (folderPath && !app.vault.getAbstractFileByPath(folderPath)) {
-        await app.vault.createFolder(folderPath);
+      // Ensure the parent folder chain of the full note path — not just the
+      // configured base folder — since the formatted filename may itself
+      // contain "/" segments. createFolder creates intermediate folders.
+      const parentDir = path.split("/").slice(0, -1).join("/");
+      if (parentDir && !app.vault.getAbstractFileByPath(parentDir)) {
+        await app.vault.createFolder(parentDir);
       }
 
       let content = "";

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -4110,18 +4110,21 @@ describe("requestHandler", () => {
       expect(res.status).toBe(404);
     });
 
-    test("period not enabled returns 400", async () => {
-      // No settings.periodicNotes.daily configured at all — regression for #255
-      // (undefined settings previously crashed rather than reporting "not enabled").
+    test("unconfigured period serves defaults rather than erroring", async () => {
+      // No settings.periodicNotes.daily configured at all — every period is
+      // always available, falling back to its built-in defaults (vault root,
+      // default format). With no matching note, that's a 404, not a 400.
+      // (Also regression coverage for #255: undefined settings once crashed.)
       const res = await request(server)
         .get("/periodic/daily/")
         .set("Authorization", `Bearer ${API_KEY}`);
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(404);
+      expect(res.body.errorCode).toBe(40461);
     });
 
     test("note does not exist returns 404, not a crash", async () => {
       settings.periodicNotes = {
-        daily: { enabled: true, folder: "", format: "YYYY-MM-DD", template: "" },
+        daily: { folder: "", format: "YYYY-MM-DD", template: "" },
       };
       // No matching file in app.vault.getMarkdownFiles() — note doesn't exist yet.
       const res = await request(server)
@@ -4132,7 +4135,7 @@ describe("requestHandler", () => {
 
     test("note exists returns 200 with file content", async () => {
       settings.periodicNotes = {
-        daily: { enabled: true, folder: "", format: "YYYY-MM-DD", template: "" },
+        daily: { folder: "", format: "YYYY-MM-DD", template: "" },
       };
       const noteFile = new TFile();
       noteFile.path = `${window.moment().format("YYYY-MM-DD")}.md`;
@@ -4147,7 +4150,7 @@ describe("requestHandler", () => {
 
     test("note in configured folder is found", async () => {
       settings.periodicNotes = {
-        daily: { enabled: true, folder: "journal", format: "YYYY-MM-DD", template: "" },
+        daily: { folder: "journal", format: "YYYY-MM-DD", template: "" },
       };
       const noteFile = new TFile();
       const basename = window.moment().format("YYYY-MM-DD");
@@ -4163,7 +4166,7 @@ describe("requestHandler", () => {
 
     test("note outside configured folder is not found", async () => {
       settings.periodicNotes = {
-        daily: { enabled: true, folder: "journal", format: "YYYY-MM-DD", template: "" },
+        daily: { folder: "journal", format: "YYYY-MM-DD", template: "" },
       };
       const noteFile = new TFile();
       const basename = window.moment().format("YYYY-MM-DD");

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,6 @@ export enum ErrorCode {
   InvalidPatchVersionHeader = 40082,
   HeaderTargetingRequiresVersion1 = 40083,
   PatchHeaderTargetingRequiresExplicitVersion = 40084,
-  PeriodIsNotEnabled = 40060,
   InvalidFilterQuery = 40070,
   PatchFailed = 40080,
   InvalidPatchInstruction = 40081,
@@ -40,7 +39,6 @@ export enum ErrorCode {
 export type PeriodicNotePeriod = "daily" | "weekly" | "monthly" | "quarterly" | "yearly";
 
 export interface PeriodicNotePeriodSettings {
-  enabled: boolean;
   folder: string;
   format: string;
   template: string;
@@ -72,7 +70,6 @@ export interface PeriodicNoteInterface {
     format: string;
     template: string;
   };
-  loaded: boolean;
   create: (date: Moment) => Promise<TFile>;
   get: (date: Moment, all: Record<string, TFile>) => TFile;
   getAll: () => Record<string, TFile>;

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -580,9 +580,6 @@ export class VaultOperations {
     if (!match) {
       return [null, ErrorCode.PeriodDoesNotExist];
     }
-    if (!match.loaded) {
-      return [null, ErrorCode.PeriodIsNotEnabled];
-    }
     return [match, null];
   }
 


### PR DESCRIPTION
Two fixes to the native periodic-notes implementation (#308) ahead of the 5.0 release.

## Slash-containing date formats

Core Daily Notes supports formats like `YYYY/MM/YYYY-MM-DD`, where the formatted filename spans subfolders beneath the configured folder — and the seed-once migration copies exactly such formats into our settings. The native implementation broke these in both directions:

- **`create()`** only ensured the configured base folder existed, so `vault.create` failed on the missing intermediate folders. The old `obsidian-daily-notes-interface` created the full parent chain; we now do the same.
- **`getAll()`** strictly parsed only the file's *basename* against the full format, so existing notes were invisible to reads. A slash-containing format is now matched against the file's folder-relative path. (This read-side case was broken in the old library too — it's a fix, not just parity.)

Formats without a slash keep the existing basename matching, including notes manually nested under the configured folder. Written test-first per the repo's TDD convention (first commit adds the failing tests).

## Always-available periods

The per-period **Enable** toggle from #308 added a failure mode with no real upside: requests for an unconfigured period returned `400 PeriodIsNotEnabled` (40060), where serving the period with sensible defaults (vault root, the period's standard filename format such as `YYYY-MM-DD`/`gggg-[W]ww`, no template) costs nothing and just works.

- Every period is now always available; the settings section configures folder / date format / template only.
- Each period's settings sub-page display value now shows the effective location and format (e.g. `journal/ · YYYY-MM-DD`).
- `ErrorCode.PeriodIsNotEnabled` and `PeriodicNoteInterface.loaded` are removed (fine under the 5.0 major bump).
- The seed-once migration still imports config only from source-plugin periods that were enabled there, on the theory that a disabled period's config may be stale — but the imported settings no longer carry an enabled flag.
- MCP `periodic_note_get_path` description, OpenAPI periodic descriptions, and the README now say where configuration lives and that defaults apply — previously nothing documented the new configuration source.

## Testing

- `npm test` — 399 passing (4 new)
- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run build-docs` all clean
- Integration tests not yet run against live Obsidian; the periodic suite is gated behind `OBSIDIAN_PERIODIC_NOTES=true` and worth running before the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)