### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Local REST API with MCP
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fcoddingtonbear%2Fobsidian-local-rest-api.svg)](https://mcptoplist.com/server/glama%2Fcoddingtonbear%2Fobsidian-local-rest-api)
+
 Give your scripts, browser extensions, and AI agents a direct line into your Obsidian vault via a secure, authenticated REST API.
 
 - **Interactive API docs:** https://coddingtonbear.github.io/obsidian-local-rest-api/


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,919 MCP servers across the major
registries, and **obsidian-local-rest-api** is currently ranked **#277**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fcoddingtonbear%2Fobsidian-local-rest-api.svg)](https://mcptoplist.com/server/glama%2Fcoddingtonbear%2Fobsidian-local-rest-api)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building obsidian-local-rest-api!
