### PR TITLE
Add three candidate marketing sites under docs/site/

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,0 +1,48 @@
+# Marketing site candidates
+
+Three complete candidate marketing sites for the plugin, plus a chooser page at
+`index.html` that links to all three. Nothing here is published as *the* site yet —
+they ship under `/site/` so they can be compared in a real browser before one is chosen.
+
+| Directory | Direction | Pitched at |
+|---|---|---|
+| `terminal/` | Dark, built around a live request/response transcript | Developers evaluating the REST API |
+| `datasheet/` | Light, reference-like, full endpoint matrix on the page | People who want to know it is documented |
+| `conversation/` | Editorial, built around what an agent does to a vault | People connecting an AI agent |
+
+Each page is a single self-contained `index.html`: no external CSS, JavaScript, fonts,
+or images, and so no third-party requests from a site whose whole pitch is that nothing
+leaves your machine. They use system font stacks, support light and dark, and carry the
+same facts, the same comparison against the alternatives, and the same two calls to
+action (install, and the interactive API reference).
+
+## Where they are published
+
+`.github/workflows/deploy-docs.yml` publishes the whole of `docs/` to GitHub Pages on
+tag push or manual dispatch, so once merged these are reachable at:
+
+- <https://coddingtonbear.github.io/obsidian-local-rest-api/site/>
+- `…/site/terminal/`, `…/site/datasheet/`, `…/site/conversation/`
+
+To see them before a release, run the **Deploy Docs** workflow manually, or serve
+locally with `npm run serve-docs` and open `/site/`.
+
+## Promoting the chosen one to the site root
+
+The root URL <https://coddingtonbear.github.io/obsidian-local-rest-api/> currently serves
+the Stoplight Elements viewer, and it is referenced from the README, the plugin's
+settings pages, the MCP tool descriptions, and third-party documentation. Promotion must
+not break it. The intended sequence:
+
+1. Move the Elements viewer to `docs/api/index.html`, keeping `docs/openapi.yaml` where it
+   is (adjust the viewer's `apiDescriptionUrl` to `../openapi.yaml`).
+2. Leave a redirect at the old root that sends visitors to `/api/`, so every existing link
+   keeps working rather than landing on the marketing page.
+3. Copy the chosen candidate to `docs/index.html` and repoint its "API docs" links —
+   currently absolute — at `/obsidian-local-rest-api/api/`.
+4. Update the README, `src/main.ts`'s settings links, and the OpenAPI `externalDocs` URL
+   to match.
+5. Delete the two candidates that were not chosen, and this directory's chooser page.
+
+Step 2 is the part worth being careful about: the docs URL has been stable for years and
+is quoted in places outside this repository.

--- a/docs/site/conversation/index.html
+++ b/docs/site/conversation/index.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Local REST API with MCP — give your agent the keys to your Obsidian vault</title>
+<meta name="description" content="An Obsidian plugin that serves a built-in MCP server and a full REST API from inside the app, so AI agents work with your live vault instead of a copy of your folder.">
+<link rel="icon" type="image/png" href="../../favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="../../favicon-16x16.png" sizes="16x16">
+<style>
+/* ---------------------------------------------------------------------------
+   Direction: "the exchange". The reader is deciding whether to let an agent
+   into their notes, so the page is built out of the thing they are deciding
+   about: someone asks for something, tools run, and the vault changes. Human
+   voice is set in a serif; the machine's half of every exchange is monospace.
+   Ground is a cool slate-green paper — a notebook, not a terminal — with one
+   deep teal doing all the work.
+   --------------------------------------------------------------------------- */
+:root {
+  --paper: #edf1ee;
+  --card: #f9fbf9;
+  --card-2: #e4ebe6;
+  --rule: #d3ddd7;
+  --rule-soft: #e0e8e3;
+  --ink: #13201b;
+  --ink-2: #42544c;
+  --muted: #77877e;
+  --accent: #0e6e62;
+  --accent-2: #0a544a;
+  --wash: #e2ede9;
+  --on-accent: #f4fbf9;
+  --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", "Cascadia Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --col: 720px;
+  --wide: 1080px;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #0f1614;
+    --card: #16201d;
+    --card-2: #1c2724;
+    --rule: #27342f;
+    --rule-soft: #202b28;
+    --ink: #e3ebe6;
+    --ink-2: #a7b7af;
+    --muted: #7b8c84;
+    --accent: #5fd9c0;
+    --accent-2: #86e6d2;
+    --wash: #16302b;
+    --on-accent: #06201c;
+    color-scheme: dark;
+  }
+}
+:root[data-theme="dark"] {
+  --paper: #0f1614;
+  --card: #16201d;
+  --card-2: #1c2724;
+  --rule: #27342f;
+  --rule-soft: #202b28;
+  --ink: #e3ebe6;
+  --ink-2: #a7b7af;
+  --muted: #7b8c84;
+  --accent: #5fd9c0;
+  --accent-2: #86e6d2;
+  --wash: #16302b;
+  --on-accent: #06201c;
+  color-scheme: dark;
+}
+:root[data-theme="light"] {
+  --paper: #edf1ee;
+  --card: #f9fbf9;
+  --card-2: #e4ebe6;
+  --rule: #d3ddd7;
+  --rule-soft: #e0e8e3;
+  --ink: #13201b;
+  --ink-2: #42544c;
+  --muted: #77877e;
+  --accent: #0e6e62;
+  --accent-2: #0a544a;
+  --wash: #e2ede9;
+  --on-accent: #f4fbf9;
+  color-scheme: light;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-underline-offset: 3px; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+h1, h2, h3 { margin: 0; font-family: var(--serif); font-weight: 600; line-height: 1.14; letter-spacing: -0.014em; text-wrap: balance; }
+p { margin: 0; }
+code { font-family: var(--mono); font-size: .88em; }
+
+.col { width: min(100% - 44px, var(--col)); margin-inline: auto; }
+.wide { width: min(100% - 44px, var(--wide)); margin-inline: auto; }
+
+/* --------------------------------- nav ----------------------------------- */
+.top { border-bottom: 1px solid var(--rule); background: color-mix(in srgb, var(--paper) 88%, transparent); backdrop-filter: blur(10px); position: sticky; top: 0; z-index: 30; }
+.top .wide { display: flex; align-items: center; gap: 22px; height: 60px; }
+.brand { margin-right: auto; text-decoration: none; color: var(--ink); font-family: var(--serif); font-size: 18.5px; font-weight: 600; }
+.brand em { font-style: normal; color: var(--accent); }
+.top nav { display: flex; align-items: center; gap: 20px; }
+.top nav a { color: var(--ink-2); text-decoration: none; font-size: 14.5px; }
+.top nav a:hover { color: var(--accent); }
+/* The button in the nav is a button first: out-specify `.top nav a`, or its
+   label inherits the nav's ink colour and disappears into the accent fill. */
+.top nav a.btn-solid { color: var(--on-accent); }
+.top nav a.btn-solid:hover { color: var(--on-accent); }
+@media (max-width: 760px) { .top nav a.hide-sm { display: none; } }
+
+.btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 19px; border-radius: 999px; font-size: 15px; font-weight: 600; text-decoration: none; border: 1px solid transparent; }
+.btn-solid { background: var(--accent); color: var(--on-accent); }
+.btn-solid:hover { background: var(--accent-2); }
+.btn-line { border-color: var(--rule); color: var(--ink); background: var(--card); }
+.btn-line:hover { border-color: var(--accent); color: var(--accent); }
+.btn-sm { padding: 7px 14px; font-size: 13.6px; }
+
+/* --------------------------------- hero ---------------------------------- */
+.hero { padding: 84px 0 64px; }
+@media (max-width: 760px) { .hero { padding: 52px 0 44px; } }
+.hero .col { text-align: left; }
+.overline { font-family: var(--mono); font-size: 11.5px; letter-spacing: .17em; text-transform: uppercase; color: var(--muted); margin-bottom: 20px; }
+h1 { font-size: clamp(38px, 5.6vw, 60px); letter-spacing: -0.026em; }
+h1 em { font-style: italic; color: var(--accent); }
+.hero p.lede { margin-top: 24px; font-size: clamp(17.5px, 1.5vw, 20px); color: var(--ink-2); }
+.hero .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
+.hero .fineprint { margin-top: 18px; font-size: 14px; color: var(--muted); }
+
+/* --------------------------- the exchange device -------------------------- */
+.exchange {
+  border: 1px solid var(--rule); border-radius: 16px; background: var(--card);
+  overflow: hidden; margin-top: 44px;
+}
+.ex-ask {
+  padding: 22px 26px; border-bottom: 1px solid var(--rule-soft);
+  font-family: var(--serif); font-size: 20px; font-style: italic; line-height: 1.45; color: var(--ink);
+  display: flex; gap: 14px; align-items: baseline;
+}
+.ex-ask::before { content: "You"; font-family: var(--mono); font-style: normal; font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); flex: none; padding-top: 4px; }
+.ex-run { padding: 18px 26px; background: var(--card-2); border-bottom: 1px solid var(--rule-soft); display: grid; gap: 9px; }
+.ex-run .step { font-family: var(--mono); font-size: 13px; color: var(--ink-2); display: flex; gap: 10px; align-items: baseline; }
+.ex-run .step b { color: var(--accent); font-weight: 500; }
+.ex-run .step span.arg { color: var(--muted); }
+.ex-out { padding: 20px 26px 22px; display: flex; gap: 14px; align-items: baseline; }
+.ex-out::before { content: "Vault"; font-family: var(--mono); font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); flex: none; padding-top: 4px; }
+.ex-out p { color: var(--ink-2); font-size: 15.5px; }
+.ex-out strong { color: var(--ink); font-weight: 600; }
+
+/* -------------------------------- sections -------------------------------- */
+section { padding: 72px 0; }
+@media (max-width: 760px) { section { padding: 52px 0; } }
+.band { background: var(--card); border-block: 1px solid var(--rule); }
+h2 { font-size: clamp(27px, 3.4vw, 38px); }
+.lead { margin-top: 18px; font-size: 17.5px; color: var(--ink-2); }
+.kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: .17em; text-transform: uppercase; color: var(--accent); margin-bottom: 16px; }
+.prose > * + * { margin-top: 22px; }
+.prose p { color: var(--ink-2); }
+
+/* capability list, kept plain — this page argues in sentences, not cards */
+.caps { margin: 34px 0 0; padding: 0; list-style: none; display: grid; gap: 1px; background: var(--rule-soft); border: 1px solid var(--rule); border-radius: 14px; overflow: hidden; }
+.caps li { background: var(--card); padding: 18px 22px; display: grid; grid-template-columns: 200px minmax(0,1fr); gap: 20px; align-items: baseline; }
+@media (max-width: 640px) { .caps li { grid-template-columns: 1fr; gap: 6px; } }
+.caps b { font-weight: 650; font-size: 15.6px; }
+.caps span { color: var(--ink-2); font-size: 15.4px; }
+.band .caps li { background: var(--paper); }
+
+/* comparison */
+.table-wrap { overflow-x: auto; border: 1px solid var(--rule); border-radius: 14px; background: var(--card); margin-top: 30px; }
+.band .table-wrap { background: var(--paper); }
+table { border-collapse: collapse; width: 100%; min-width: 680px; font-size: 14.8px; }
+th, td { text-align: left; padding: 13px 18px; border-bottom: 1px solid var(--rule-soft); vertical-align: top; }
+thead th { font-family: var(--mono); font-size: 11px; letter-spacing: .11em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+thead th.mine { color: var(--accent); }
+tbody th { font-weight: 500; color: var(--ink-2); }
+tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
+td.mine { background: var(--wash); color: var(--ink); }
+td.other { color: var(--muted); }
+.aside { margin-top: 18px; font-size: 14.6px; color: var(--muted); }
+
+/* code */
+pre { margin: 0; border: 1px solid var(--rule); border-radius: 12px; background: var(--card); padding: 18px 20px; overflow-x: auto; font-family: var(--mono); font-size: 13.2px; line-height: 1.8; }
+.band pre { background: var(--paper); }
+pre .cm { color: var(--muted); }
+pre .st { color: var(--accent); }
+.steps { display: grid; gap: 20px; margin-top: 32px; }
+.step-head { font-family: var(--mono); font-size: 11.5px; letter-spacing: .13em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
+
+/* trust panel */
+.trust { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 1px; background: var(--rule-soft); border: 1px solid var(--rule); border-radius: 14px; overflow: hidden; margin-top: 32px; }
+@media (max-width: 760px) { .trust { grid-template-columns: 1fr; } }
+.trust div { background: var(--card); padding: 22px; }
+.band .trust div { background: var(--paper); }
+.trust h3 { font-family: var(--sans); font-size: 15.5px; font-weight: 650; letter-spacing: 0; }
+.trust p { margin-top: 8px; font-size: 14.8px; color: var(--ink-2); }
+
+/* faq */
+details { border-bottom: 1px solid var(--rule); }
+details:first-of-type { border-top: 1px solid var(--rule); }
+summary { cursor: pointer; padding: 18px 0; font-weight: 600; font-size: 16.5px; list-style: none; display: flex; justify-content: space-between; gap: 16px; align-items: center; }
+summary::-webkit-details-marker { display: none; }
+summary::after { content: "+"; font-family: var(--mono); color: var(--accent); font-size: 18px; }
+details[open] summary::after { content: "–"; }
+details p { padding-bottom: 20px; color: var(--ink-2); font-size: 16px; }
+
+/* closing */
+.closing { text-align: center; padding: 92px 0 100px; }
+.closing h2 { font-size: clamp(30px, 4.2vw, 44px); }
+.closing p { margin: 18px auto 0; max-width: 52ch; color: var(--ink-2); }
+.closing .actions { display: flex; justify-content: center; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
+
+footer { border-top: 1px solid var(--rule); background: var(--card); padding: 34px 0 48px; }
+footer .wide { display: flex; flex-wrap: wrap; gap: 16px 34px; align-items: baseline; }
+footer a { color: var(--ink-2); text-decoration: none; font-size: 14.4px; }
+footer a:hover { color: var(--accent); }
+footer .rights { margin-left: auto; font-family: var(--mono); font-size: 12.4px; color: var(--muted); }
+
+@media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; transition-duration: .001ms !important; } }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="wide">
+    <a class="brand" href="#top">Local REST API <em>with MCP</em></a>
+    <nav>
+      <a href="#how" class="hide-sm">How it works</a>
+      <a href="#compare" class="hide-sm">Why this one</a>
+      <a href="#rest" class="hide-sm">REST API</a>
+      <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API docs</a>
+      <a class="btn btn-solid btn-sm" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install</a>
+    </nav>
+  </div>
+</header>
+
+<main id="top">
+
+  <section class="hero">
+    <div class="col">
+      <p class="overline">Obsidian community plugin · free · MIT</p>
+      <h1>Give your agent the keys to your vault — <em>not a copy of it.</em></h1>
+      <p class="lede">
+        This plugin runs a Model Context Protocol server and a full REST API from inside Obsidian.
+        Your agent doesn't read a folder of files on the side; it works in the vault you have open,
+        with the tags, links, search, and commands Obsidian already resolved.
+      </p>
+      <div class="actions">
+        <a class="btn btn-solid" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install from Obsidian</a>
+        <a class="btn btn-line" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Read the API docs</a>
+      </div>
+      <p class="fineprint">Runs on 127.0.0.1 behind an API key. Nothing is sent anywhere.</p>
+
+      <div class="exchange">
+        <div class="ex-ask">Add today's decisions to my project log, and file the loose ends as tasks.</div>
+        <div class="ex-run">
+          <div class="step"><b>vault_get_document_map</b> <span class="arg">Projects/API.md</span></div>
+          <div class="step"><b>vault_patch</b> <span class="arg">heading ["Log"] · append · ifMatch</span></div>
+          <div class="step"><b>search_query</b> <span class="arg">tags contains "loose-end"</span></div>
+          <div class="step"><b>vault_append</b> <span class="arg">Tasks/Inbox.md</span></div>
+        </div>
+        <div class="ex-out">
+          <p>One heading in <strong>Projects/API.md</strong> gained four lines. Nothing else in the note moved, and Obsidian — still open in front of you — shows the change immediately.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="how" class="band">
+    <div class="col prose">
+      <p class="kicker">How it works</p>
+      <h2>An agent that can see what Obsidian sees</h2>
+      <p class="lead">
+        Most ways of getting an agent into a vault treat it as a directory of text. That works until
+        the agent needs to know which notes carry a tag, what the note in front of you is, or how to
+        change one section of a long file without rewriting the whole thing.
+      </p>
+      <p>
+        Because this server lives inside Obsidian, none of those are hard problems. It reads the
+        metadata cache the app already maintains, it can name the file you currently have open, and
+        it edits by address — a heading path, a block reference, a frontmatter key — rather than by
+        rewriting bytes. Writes go through Obsidian's own vault API, so the app you are looking at
+        never misses a change or overwrites one.
+      </p>
+
+      <ul class="caps">
+        <li><b>Read and write</b><span>Any file in the vault, including attachments — plus the note that happens to be open right now.</span></li>
+        <li><b>Edit by address</b><span>Append under a heading, replace a block, set a frontmatter field. Optimistic concurrency stops two writers from stepping on each other.</span></li>
+        <li><b>Search properly</b><span>Obsidian's own fuzzy search, or a structured JsonLogic query across frontmatter, tags, paths, and content.</span></li>
+        <li><b>Run the app</b><span>List and execute any Obsidian command, and open a note on screen when a human should look at it.</span></li>
+        <li><b>Know the vault</b><span>Every tag with its usage count; the heading, block, and frontmatter map of any file before touching it.</span></li>
+      </ul>
+    </div>
+  </section>
+
+  <section id="compare">
+    <div class="wide">
+      <div class="col prose" style="padding-left:0; padding-right:0; width:100%; max-width:var(--col); margin-inline:auto;">
+        <p class="kicker">Why this one</p>
+        <h2>Compared with pointing a filesystem server at the folder</h2>
+        <p class="lead">
+          A filesystem MCP server is genuinely simpler, and it keeps working when Obsidian is shut.
+          What it cannot do is see any of the structure Obsidian builds on top of those files — or
+          tell the running app that something changed.
+        </p>
+      </div>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">&nbsp;</th>
+              <th scope="col" class="mine">This plugin</th>
+              <th scope="col">Filesystem MCP server</th>
+              <th scope="col">Third-party REST wrapper</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Tags, links, and frontmatter</th>
+              <td class="mine">Obsidian's live metadata cache</td>
+              <td class="other">Re-parsed from the raw files</td>
+              <td class="other">Whatever this plugin returns</td>
+            </tr>
+            <tr>
+              <th scope="row">Changes reach the open app</th>
+              <td class="mine">Immediately — written through Obsidian</td>
+              <td class="other">Written behind its back</td>
+              <td class="other">Whatever this plugin does</td>
+            </tr>
+            <tr>
+              <th scope="row">Editing one section</th>
+              <td class="mine">By heading, block, or field</td>
+              <td class="other">Usually a whole-file rewrite</td>
+              <td class="other">Only what it chooses to expose</td>
+            </tr>
+            <tr>
+              <th scope="row">The note you have open</th>
+              <td class="mine">Addressable directly</td>
+              <td class="other">Unknowable</td>
+              <td class="other">Only if it proxies it</td>
+            </tr>
+            <tr>
+              <th scope="row">Obsidian commands</th>
+              <td class="mine">Listed and executable</td>
+              <td class="other">Out of reach</td>
+              <td class="other">Only if it proxies them</td>
+            </tr>
+            <tr>
+              <th scope="row">Extra software to run</th>
+              <td class="mine">None beyond the plugin</td>
+              <td class="other">A separate server</td>
+              <td class="other">A separate server, plus this plugin</td>
+            </tr>
+            <tr>
+              <th scope="row">Works with Obsidian closed</th>
+              <td class="mine other">No</td>
+              <td class="other">Yes</td>
+              <td class="other">No</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div style="max-width:var(--col); margin-inline:auto;">
+        <p class="aside">
+          The last row is the trade-off, said plainly. Worth knowing too: the popular third-party
+          Obsidian MCP servers are wrappers that call this plugin's REST API underneath — so if you
+          are running one of those, you are already running this, with an extra process in between.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section id="rest" class="band">
+    <div class="col prose">
+      <p class="kicker">Not only for agents</p>
+      <h2>The same vault, over plain HTTP</h2>
+      <p class="lead">
+        Long before MCP existed, this was a REST API — and it still is. Every capability an agent
+        gets through a tool call is also an ordinary HTTP endpoint, documented in OpenAPI, reachable
+        from a shell script, an iOS Shortcut, a browser extension, or anything else that can make a
+        request.
+      </p>
+
+<pre><span class="cm"># Append a line under a heading. No JSON escaping required.</span>
+curl -k -X PATCH \
+  -H <span class="st">"Authorization: Bearer $KEY"</span> \
+  -H <span class="st">"Operation: append"</span> \
+  -H <span class="st">"Content-Type: text/markdown"</span> \
+  --data <span class="st">"- One more thing"</span> \
+  https://127.0.0.1:27124/vault/Projects/API.md/heading/Log</pre>
+
+      <p>
+        The full reference is interactive: every route, parameter, and response shape, generated
+        from the same specification the plugin serves to MCP clients at runtime.
+      </p>
+      <p><a class="btn btn-line" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Open the interactive API documentation</a></p>
+    </div>
+  </section>
+
+  <section id="start">
+    <div class="col prose">
+      <p class="kicker">Quick start</p>
+      <h2>Three minutes, start to finish</h2>
+      <p class="lead">Install the plugin from Obsidian's community browser, then open <strong>Settings → Local REST API</strong> and copy your API key.</p>
+
+      <div class="steps">
+        <div>
+          <p class="step-head">Claude Code</p>
+<pre>claude mcp add --transport http obsidian https://127.0.0.1:27124/mcp/ \
+  --header <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span></pre>
+        </div>
+        <div>
+          <p class="step-head">Cursor · ~/.cursor/mcp.json</p>
+<pre>{
+  "mcpServers": {
+    "obsidian": {
+      "url": <span class="st">"https://127.0.0.1:27124/mcp/"</span>,
+      "headers": { "Authorization": <span class="st">"Bearer &lt;your-api-key&gt;"</span> }
+    }
+  }
+}</pre>
+        </div>
+        <div>
+          <p class="step-head">Claude Desktop · via mcp-remote</p>
+<pre>{
+  "mcpServers": {
+    "obsidian": {
+      "command": <span class="st">"npx"</span>,
+      "args": [
+        <span class="st">"mcp-remote@latest"</span>,
+        <span class="st">"https://127.0.0.1:27124/mcp/"</span>,
+        <span class="st">"--header"</span>,
+        <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span>
+      ]
+    }
+  }
+}</pre>
+        </div>
+      </div>
+      <p class="aside">Any client that speaks the Streamable HTTP transport works the same way: that URL, that header.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <div class="col prose">
+      <p class="kicker">Trust</p>
+      <h2>Your notes stay on your machine</h2>
+      <p class="lead">
+        This is a local server, not a service. There is no account, no telemetry, and no upstream —
+        the only things that reach your vault are the clients you hand a key to.
+      </p>
+
+      <div class="trust">
+        <div>
+          <h3>Loopback by default</h3>
+          <p>The server binds to 127.0.0.1. Nothing on your network can reach it unless you deliberately change that.</p>
+        </div>
+        <div>
+          <h3>Authenticated everywhere</h3>
+          <p>Every route but the status check requires your bearer API key, over HTTPS with a certificate generated on your machine.</p>
+        </div>
+        <div>
+          <h3>Open source</h3>
+          <p>MIT licensed, developed in the open, and reviewed by the Obsidian community plugin process.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="faq">
+    <div class="col prose">
+      <p class="kicker">Questions</p>
+      <h2>Before you install</h2>
+      <div style="margin-top:28px;">
+        <details open>
+          <summary>Does Obsidian have to be open?</summary>
+          <p>Yes — and that is what makes the difference. The metadata cache, the active file, Obsidian's search, and the command palette all live inside a running app. If you specifically want vault access while Obsidian is closed, a filesystem tool is the better fit.</p>
+        </details>
+        <details>
+          <summary>Do I still need a third-party Obsidian MCP server?</summary>
+          <p>No. The MCP server is built into the plugin, so there is no bridge process to install, configure, or keep up to date — and the popular third-party servers are wrappers around this plugin's REST API anyway.</p>
+        </details>
+        <details>
+          <summary>What about the certificate warning?</summary>
+          <p>The certificate is self-signed because it is issued locally for a loopback address. Trust it from <code>https://127.0.0.1:27124/obsidian-local-rest-api.crt</code>, hand it to your client directly, or enable the optional plain-HTTP port for clients that cannot be talked round.</p>
+        </details>
+        <details>
+          <summary>Can an agent destroy my notes?</summary>
+          <p>It has the access you grant it, so treat the API key as you would any other credential — and keep your vault in version control or a backup, as you would anyway. Deletes move files to the trash by default, section edits touch only the section they name, and an <code>ifMatch</code> token lets a careful client refuse to write over a file that changed underneath it.</p>
+        </details>
+        <details>
+          <summary>Does it work on mobile?</summary>
+          <p>No, desktop only. The plugin needs Node's TLS and HTTP server APIs, which Obsidian's mobile runtime does not provide.</p>
+        </details>
+        <details>
+          <summary>Can my own plugin add to the API?</summary>
+          <p>Yes. Plugins can register their own authenticated routes and MCP tools on this server, and a published, generated type package means the whole host surface is checked at compile time.</p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <section class="closing band">
+    <div class="col">
+      <h2>Let it work where you work.</h2>
+      <p>Free, open source, and installed from Obsidian's community plugin browser in about a minute.</p>
+      <div class="actions">
+        <a class="btn btn-solid" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install the plugin</a>
+        <a class="btn btn-line" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Interactive API docs</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <div class="wide">
+    <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API documentation</a>
+    <a href="https://github.com/coddingtonbear/obsidian-local-rest-api">GitHub</a>
+    <a href="https://community.obsidian.md/plugins/obsidian-local-rest-api/">Community plugin page</a>
+    <a href="https://github.com/coddingtonbear/obsidian-local-rest-api/wiki/Adding-your-own-API-Routes-via-an-Extension">Build an extension</a>
+    <span class="rights">MIT · Adam Coddington</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/site/datasheet/index.html
+++ b/docs/site/datasheet/index.html
@@ -1,0 +1,672 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Local REST API with MCP — the documented interface to your Obsidian vault</title>
+<meta name="description" content="A secure REST API and Model Context Protocol server that runs inside Obsidian. Fully documented, section-level editing, sixteen MCP tools, extensible by other plugins.">
+<link rel="icon" type="image/png" href="../../favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="../../favicon-16x16.png" sizes="16x16">
+<style>
+/* ---------------------------------------------------------------------------
+   Direction: "datasheet". The audience arrives asking what the thing does and
+   whether it is documented, so the page reads like the cover sheet of a good
+   reference manual: a persistent contents rail, sections that announce
+   themselves, and a specification table doing the heavy lifting. Serif
+   headings against a cool paper, with oxblood as the single mark of emphasis.
+   --------------------------------------------------------------------------- */
+:root {
+  --paper: #f4f5f7;
+  --card: #ffffff;
+  --card-2: #eef0f4;
+  --rule: #d9dee5;
+  --rule-soft: #e6eaef;
+  --ink: #161d27;
+  --ink-2: #46525f;
+  --muted: #788593;
+  --accent: #8e2c3b;
+  --accent-2: #b4535f;
+  --accent-wash: #f6ecee;
+  --on-accent: #ffffff;
+  --ok: #1f6b4d;
+  --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", "Cascadia Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --measure: 66ch;
+  --shell: 1160px;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #13171d;
+    --card: #191e26;
+    --card-2: #1f252e;
+    --rule: #2b333d;
+    --rule-soft: #232a33;
+    --ink: #e7ecf2;
+    --ink-2: #aab6c3;
+    --muted: #7c8896;
+    --accent: #e58394;
+    --accent-2: #c96878;
+    --accent-wash: #241a1d;
+    --on-accent: #1a1013;
+    --ok: #6cc79c;
+    color-scheme: dark;
+  }
+}
+:root[data-theme="dark"] {
+  --paper: #13171d;
+  --card: #191e26;
+  --card-2: #1f252e;
+  --rule: #2b333d;
+  --rule-soft: #232a33;
+  --ink: #e7ecf2;
+  --ink-2: #aab6c3;
+  --muted: #7c8896;
+  --accent: #e58394;
+  --accent-2: #c96878;
+  --accent-wash: #241a1d;
+  --on-accent: #1a1013;
+  --ok: #6cc79c;
+  color-scheme: dark;
+}
+:root[data-theme="light"] {
+  --paper: #f4f5f7;
+  --card: #ffffff;
+  --card-2: #eef0f4;
+  --rule: #d9dee5;
+  --rule-soft: #e6eaef;
+  --ink: #161d27;
+  --ink-2: #46525f;
+  --muted: #788593;
+  --accent: #8e2c3b;
+  --accent-2: #b4535f;
+  --accent-wash: #f6ecee;
+  --on-accent: #ffffff;
+  --ok: #1f6b4d;
+  color-scheme: light;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16.5px;
+  line-height: 1.68;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-underline-offset: 3px; text-decoration-thickness: 1px; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 3px; }
+h1, h2, h3, h4 { margin: 0; text-wrap: balance; font-family: var(--serif); font-weight: 600; line-height: 1.15; letter-spacing: -0.012em; }
+p { margin: 0; }
+code { font-family: var(--mono); font-size: .9em; }
+
+.shell { width: min(100% - 44px, var(--shell)); margin-inline: auto; }
+
+/* ------------------------------- masthead -------------------------------- */
+.masthead { border-bottom: 1px solid var(--rule); background: var(--card); position: sticky; top: 0; z-index: 40; }
+.masthead .shell { display: flex; align-items: center; gap: 20px; height: 60px; }
+.mark {
+  display: flex; align-items: baseline; gap: 9px; margin-right: auto;
+  text-decoration: none; color: var(--ink); font-family: var(--serif); font-size: 18px; font-weight: 600;
+}
+.mark span.sub { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); }
+.masthead nav { display: flex; align-items: center; gap: 20px; }
+.masthead nav a { color: var(--ink-2); text-decoration: none; font-size: 14.5px; }
+.masthead nav a:hover { color: var(--accent); }
+.pill {
+  border: 1px solid var(--accent); color: var(--accent);
+  padding: 6px 13px; border-radius: 999px; font-size: 13.5px; font-weight: 600; text-decoration: none;
+}
+/* Out-specify `.masthead nav a`, which would otherwise win on the hover fill. */
+.masthead nav a.pill { color: var(--accent); }
+.masthead nav a.pill:hover { background: var(--accent); color: var(--on-accent); }
+@media (max-width: 800px) { .masthead nav a.hide-sm { display: none; } }
+
+/* --------------------------------- hero ---------------------------------- */
+.hero { border-bottom: 1px solid var(--rule); background: var(--card); }
+.hero .shell { padding: 72px 0 60px; display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr); gap: 56px; align-items: start; }
+@media (max-width: 900px) { .hero .shell { grid-template-columns: 1fr; gap: 36px; padding: 48px 0 44px; } }
+.kicker {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase;
+  color: var(--accent); padding-bottom: 14px; margin-bottom: 22px; border-bottom: 1px solid var(--rule);
+}
+h1 { font-size: clamp(36px, 5vw, 56px); letter-spacing: -0.024em; }
+.hero .lede { margin-top: 20px; font-size: clamp(17px, 1.4vw, 19px); color: var(--ink-2); max-width: var(--measure); }
+.hero .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }
+.btn {
+  display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px;
+  border-radius: 6px; font-size: 15px; font-weight: 600; text-decoration: none; border: 1px solid transparent;
+}
+.btn-solid { background: var(--accent); color: var(--on-accent); }
+.btn-solid:hover { background: var(--accent-2); }
+.btn-line { border-color: var(--rule); color: var(--ink); background: var(--paper); }
+.btn-line:hover { border-color: var(--accent); color: var(--accent); }
+
+/* spec block in the hero — the datasheet conceit, stated up front */
+.spec { border: 1px solid var(--rule); border-radius: 8px; background: var(--paper); overflow: hidden; }
+.spec-head {
+  padding: 11px 16px; border-bottom: 1px solid var(--rule); background: var(--card-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted);
+}
+.spec dl { margin: 0; display: grid; grid-template-columns: max-content 1fr; }
+.spec dt, .spec dd {
+  margin: 0; padding: 11px 16px; border-bottom: 1px solid var(--rule-soft);
+  font-size: 14px; font-variant-numeric: tabular-nums;
+}
+.spec dt { font-family: var(--mono); font-size: 12px; letter-spacing: .05em; text-transform: uppercase; color: var(--muted); border-right: 1px solid var(--rule-soft); white-space: nowrap; }
+.spec dd { color: var(--ink); }
+.spec dl > :nth-last-child(-n+2) { border-bottom: 0; }
+
+/* ------------------------------- body grid ------------------------------- */
+.body-grid { display: grid; grid-template-columns: 200px minmax(0, 1fr); gap: 56px; align-items: start; padding: 56px 0 24px; }
+@media (max-width: 940px) { .body-grid { grid-template-columns: 1fr; gap: 0; padding-top: 36px; } }
+.rail { position: sticky; top: 88px; }
+@media (max-width: 940px) { .rail { display: none; } }
+.rail p {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--muted); padding-bottom: 10px; border-bottom: 1px solid var(--rule);
+}
+.rail ol { list-style: none; margin: 14px 0 0; padding: 0; display: grid; gap: 9px; counter-reset: r; }
+.rail a { display: block; text-decoration: none; color: var(--ink-2); font-size: 14px; }
+.rail a:hover, .rail a[aria-current="true"] { color: var(--accent); }
+
+section { padding: 0 0 72px; scroll-margin-top: 84px; }
+.sec-head { border-top: 1px solid var(--rule); padding-top: 18px; margin-bottom: 28px; }
+.sec-head .tag {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase; color: var(--accent);
+}
+.sec-head h2 { font-size: clamp(25px, 3vw, 33px); margin-top: 12px; }
+.sec-head p { margin-top: 14px; color: var(--ink-2); max-width: var(--measure); }
+
+/* capability list — a manual's numbered entries, because these really are a set */
+.caps { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 1px; background: var(--rule-soft); border: 1px solid var(--rule); border-radius: 8px; overflow: hidden; }
+@media (max-width: 760px) { .caps { grid-template-columns: 1fr; } }
+.cap { background: var(--card); padding: 22px 22px 20px; }
+.cap h3 { font-family: var(--sans); font-size: 16px; font-weight: 650; letter-spacing: -0.005em; }
+.cap p { margin-top: 8px; font-size: 14.8px; color: var(--ink-2); }
+.cap .route { margin-top: 12px; font-family: var(--mono); font-size: 12.4px; color: var(--muted); }
+.cap .route b { color: var(--accent); font-weight: 500; }
+
+/* endpoint matrix */
+.table-wrap { overflow-x: auto; border: 1px solid var(--rule); border-radius: 8px; background: var(--card); }
+table { border-collapse: collapse; width: 100%; min-width: 640px; font-size: 14.6px; }
+caption { text-align: left; padding: 14px 18px; border-bottom: 1px solid var(--rule); background: var(--card-2); font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); }
+th, td { text-align: left; padding: 12px 18px; border-bottom: 1px solid var(--rule-soft); vertical-align: top; }
+thead th { font-family: var(--mono); font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
+tbody th { font-family: var(--mono); font-size: 13.4px; font-weight: 500; color: var(--ink); white-space: nowrap; }
+td.verbs { font-family: var(--mono); font-size: 12.6px; color: var(--accent); white-space: nowrap; }
+td.note { color: var(--ink-2); }
+th.mine, td.mine { background: var(--accent-wash); }
+th.mine { color: var(--accent); }
+td.y { color: var(--ok); }
+td.n { color: var(--muted); }
+.foot-note { margin-top: 14px; font-size: 13.8px; color: var(--muted); max-width: var(--measure); }
+
+/* code */
+pre.block {
+  margin: 0; border: 1px solid var(--rule); border-radius: 8px; background: var(--card);
+  padding: 18px 20px; overflow-x: auto; font-family: var(--mono); font-size: 13.2px; line-height: 1.78;
+}
+pre.block .cm { color: var(--muted); }
+pre.block .kw { color: var(--accent); }
+pre.block .st { color: var(--ok); }
+.stack { display: grid; gap: 16px; }
+.two { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 20px; }
+@media (max-width: 800px) { .two { grid-template-columns: 1fr; } }
+h4.sub { font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; font-weight: 500; }
+
+/* tool inventory */
+.tools { display: flex; flex-wrap: wrap; gap: 8px; }
+.tools li {
+  list-style: none; font-family: var(--mono); font-size: 12.8px;
+  border: 1px solid var(--rule); border-radius: 5px; padding: 6px 10px; background: var(--card); color: var(--ink-2);
+}
+.tools { padding: 0; margin: 0; }
+
+/* faq */
+details { border: 1px solid var(--rule); border-radius: 8px; background: var(--card); margin-bottom: 10px; }
+summary { cursor: pointer; padding: 15px 18px; font-weight: 600; font-size: 15.4px; list-style: none; display: flex; gap: 10px; align-items: baseline; }
+summary::-webkit-details-marker { display: none; }
+summary::before { content: "§"; font-family: var(--mono); color: var(--accent); }
+details p { padding: 0 18px 16px 36px; color: var(--ink-2); font-size: 15px; max-width: var(--measure); }
+
+/* closing */
+.closing { border-top: 1px solid var(--rule); background: var(--card); }
+.closing .shell { padding: 66px 0 72px; display: flex; flex-wrap: wrap; gap: 28px; align-items: center; justify-content: space-between; }
+.closing h2 { font-size: clamp(26px, 3.2vw, 36px); max-width: 18ch; }
+.closing p { margin-top: 12px; color: var(--ink-2); max-width: 46ch; }
+
+footer { border-top: 1px solid var(--rule); padding: 32px 0 48px; }
+footer .shell { display: flex; flex-wrap: wrap; gap: 16px 36px; align-items: baseline; }
+footer a { color: var(--ink-2); text-decoration: none; font-size: 14.4px; }
+footer a:hover { color: var(--accent); }
+footer .rights { margin-left: auto; font-family: var(--mono); font-size: 12.4px; color: var(--muted); }
+</style>
+</head>
+<body>
+
+<header class="masthead">
+  <div class="shell">
+    <a class="mark" href="#top">Local REST API <span class="sub">with MCP</span></a>
+    <nav>
+      <a href="#capabilities" class="hide-sm">Capabilities</a>
+      <a href="#endpoints" class="hide-sm">Endpoints</a>
+      <a href="#comparison" class="hide-sm">Comparison</a>
+      <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API reference</a>
+      <a class="pill" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install</a>
+    </nav>
+  </div>
+</header>
+
+<main id="top">
+
+  <div class="hero">
+    <div class="shell">
+      <div>
+        <p class="kicker">Obsidian community plugin · v5 · MIT</p>
+        <h1>The documented interface to your Obsidian vault.</h1>
+        <p class="lede">
+          One plugin serves a full REST API <em>and</em> a Model Context Protocol server from inside
+          Obsidian itself — authenticated, loopback-only, and specified end to end in OpenAPI. Point
+          curl, a browser extension, a Shortcut, or an AI agent at it and get the same vault, with
+          the same guarantees.
+        </p>
+        <div class="actions">
+          <a class="btn btn-solid" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install from Obsidian</a>
+          <a class="btn btn-line" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Interactive API reference</a>
+        </div>
+      </div>
+
+      <div class="spec">
+        <div class="spec-head">At a glance</div>
+        <dl>
+          <dt>Interfaces</dt><dd>REST + MCP (Streamable HTTP)</dd>
+          <dt>Transport</dt><dd>HTTPS on 127.0.0.1:27124</dd>
+          <dt>Auth</dt><dd>Bearer API key, every route</dd>
+          <dt>MCP tools</dt><dd>16, no bridge process</dd>
+          <dt>Edit granularity</dt><dd>Heading, block, frontmatter</dd>
+          <dt>Spec</dt><dd>OpenAPI 3, served at runtime</dd>
+          <dt>Extensible</dt><dd>Routes + tools from other plugins</dd>
+          <dt>Platform</dt><dd>Obsidian desktop, 1.13.1+</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  <div class="shell body-grid">
+    <aside class="rail">
+      <p>Contents</p>
+      <ol>
+        <li><a href="#capabilities">Capabilities</a></li>
+        <li><a href="#patching">Section-level editing</a></li>
+        <li><a href="#endpoints">Endpoint matrix</a></li>
+        <li><a href="#mcp">MCP server</a></li>
+        <li><a href="#comparison">Comparison</a></li>
+        <li><a href="#start">Quick start</a></li>
+        <li><a href="#extensions">Extensions</a></li>
+        <li><a href="#faq">Questions</a></li>
+      </ol>
+    </aside>
+
+    <div>
+      <section id="capabilities">
+        <div class="sec-head">
+          <p class="tag">Capabilities</p>
+          <h2>What the API can reach</h2>
+          <p>
+            Because the server runs inside Obsidian, it can reach things a folder of markdown does
+            not contain: the resolved metadata cache, the file you currently have open, and the
+            command palette.
+          </p>
+        </div>
+
+        <div class="caps">
+          <div class="cap">
+            <h3>Files, in full</h3>
+            <p>Create, read, update, and delete any file in the vault, including binary attachments, plus directory listings.</p>
+            <p class="route"><b>GET PUT PATCH POST DELETE</b> /vault/{path}</p>
+          </div>
+          <div class="cap">
+            <h3>Sections, in isolation</h3>
+            <p>Read or write one heading, block reference, or frontmatter field without fetching or rewriting the whole note.</p>
+            <p class="route"><b>GET PUT POST PATCH</b> /vault/{path}/heading/{…}</p>
+          </div>
+          <div class="cap">
+            <h3>The active file</h3>
+            <p>Operate on whatever note is open in front of you, without knowing its path in advance.</p>
+            <p class="route"><b>GET PUT PATCH POST DELETE</b> /active/</p>
+          </div>
+          <div class="cap">
+            <h3>Search, two ways</h3>
+            <p>Obsidian's own fuzzy search with scored context snippets, or a JsonLogic expression over each note's metadata.</p>
+            <p class="route"><b>POST</b> /search/simple/ · <b>POST</b> /search/</p>
+          </div>
+          <div class="cap">
+            <h3>Commands</h3>
+            <p>List every registered Obsidian command and execute any of them, exactly as the command palette would.</p>
+            <p class="route"><b>GET</b> /commands/ · <b>POST</b> /commands/{id}/</p>
+          </div>
+          <div class="cap">
+            <h3>Tags and the UI</h3>
+            <p>Enumerate every tag in the vault with usage counts, or tell Obsidian to open a particular note on screen.</p>
+            <p class="route"><b>GET</b> /tags/ · <b>POST</b> /open/{path}</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="patching">
+        <div class="sec-head">
+          <p class="tag">Section-level editing</p>
+          <h2>PATCH is the reason people stay</h2>
+          <p>
+            An instruction names an <strong>operation</strong> (replace, prepend, append, delete),
+            a <strong>scope</strong> (the node's content, its marker, both, or its place in the
+            tree), and a <strong>target</strong> (a heading path, a block id, a frontmatter key).
+            Heading levels in your content are rebased for you; whitespace is normalised for you;
+            an <code>ifMatch</code> token makes the write conditional on the file being unchanged.
+          </p>
+        </div>
+
+        <div class="two">
+          <div>
+            <h4 class="sub">JSON instruction</h4>
+<pre class="block">{
+  <span class="kw">"targetType"</span>: <span class="st">"heading"</span>,
+  <span class="kw">"target"</span>: [<span class="st">"Work"</span>, <span class="st">"Log"</span>],
+  <span class="kw">"operation"</span>: <span class="st">"append"</span>,
+  <span class="kw">"content"</span>: <span class="st">"- Shipped the release"</span>,
+  <span class="kw">"ifMatch"</span>: <span class="st">"&lt;version from the document map&gt;"</span>
+}</pre>
+          </div>
+          <div>
+            <h4 class="sub">Or move the fields out of the body</h4>
+<pre class="block"><span class="cm"># Target in the URL, operation in a header,
+# body is the raw payload — nothing to escape.</span>
+curl -k -X PATCH \
+  -H <span class="st">"Authorization: Bearer $KEY"</span> \
+  -H <span class="st">"Operation: append"</span> \
+  -H <span class="st">"Content-Type: text/markdown"</span> \
+  --data <span class="st">"- $TEMPLATED_LINE"</span> \
+  <span class="cm">…</span>/vault/daily.md/heading/Log</pre>
+          </div>
+        </div>
+        <p class="foot-note">
+          Raw-content mode exists because clients that template markdown — Shortcuts, Tasker, a
+          shell script — should not have to JSON-escape it. Both forms drive the same engine.
+        </p>
+      </section>
+
+      <section id="endpoints">
+        <div class="sec-head">
+          <p class="tag">Endpoint matrix</p>
+          <h2>The whole surface on one page</h2>
+          <p>Every route, with the methods it accepts. Full request and response schemas live in the interactive reference.</p>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <caption>REST endpoints</caption>
+            <thead>
+              <tr><th scope="col">Route</th><th scope="col">Methods</th><th scope="col">Purpose</th></tr>
+            </thead>
+            <tbody>
+              <tr><th scope="row">/vault/{path}</th><td class="verbs">GET PUT PATCH POST DELETE</td><td class="note">Read, write, patch, or delete any file</td></tr>
+              <tr><th scope="row">/active/</th><td class="verbs">GET PUT PATCH POST DELETE</td><td class="note">The same, against the currently open note</td></tr>
+              <tr><th scope="row">/search/simple/</th><td class="verbs">POST</td><td class="note">Obsidian's fuzzy search, with scored snippets</td></tr>
+              <tr><th scope="row">/search/</th><td class="verbs">POST</td><td class="note">JsonLogic query over note metadata</td></tr>
+              <tr><th scope="row">/commands/</th><td class="verbs">GET</td><td class="note">List registered Obsidian commands</td></tr>
+              <tr><th scope="row">/commands/{id}/</th><td class="verbs">POST</td><td class="note">Execute a command</td></tr>
+              <tr><th scope="row">/tags/</th><td class="verbs">GET</td><td class="note">Every tag in the vault, with usage counts</td></tr>
+              <tr><th scope="row">/open/{path}</th><td class="verbs">POST</td><td class="note">Open a note in the Obsidian UI</td></tr>
+              <tr><th scope="row">/mcp/</th><td class="verbs">GET POST</td><td class="note">Model Context Protocol server</td></tr>
+              <tr><th scope="row">/</th><td class="verbs">GET</td><td class="note">Status and authentication check</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="foot-note">
+          <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Open the interactive reference →</a>
+        </p>
+      </section>
+
+      <section id="mcp">
+        <div class="sec-head">
+          <p class="tag">MCP server</p>
+          <h2>Sixteen tools, already inside the app</h2>
+          <p>
+            The Model Context Protocol server is part of the plugin, not a separate process wrapping
+            it. Connect any Streamable HTTP client to <code>/mcp/</code> with the same bearer token,
+            and it gets the same live vault the REST API does.
+          </p>
+        </div>
+
+        <ul class="tools">
+          <li>vault_list</li><li>vault_read</li><li>vault_write</li><li>vault_append</li>
+          <li>vault_patch</li><li>vault_delete</li><li>vault_move</li><li>vault_copy</li>
+          <li>vault_get_document_map</li><li>active_file_get_path</li><li>search_query</li>
+          <li>search_simple</li><li>tag_list</li><li>command_list</li><li>command_execute</li><li>open_file</li>
+        </ul>
+
+        <p class="foot-note" style="margin-top:18px;">
+          The server also publishes its own OpenAPI specification as an MCP resource, so a capable
+          client can read the full API contract without being told about it.
+        </p>
+      </section>
+
+      <section id="comparison">
+        <div class="sec-head">
+          <p class="tag">Comparison</p>
+          <h2>Against the alternatives</h2>
+          <p>
+            Three architectures are commonly used to get an agent into an Obsidian vault. They are
+            not equivalent, and the differences are mostly about what the server can see.
+          </p>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <caption>Architectures compared</caption>
+            <thead>
+              <tr>
+                <th scope="col">&nbsp;</th>
+                <th scope="col" class="mine">This plugin</th>
+                <th scope="col">Filesystem MCP server</th>
+                <th scope="col">Third-party REST wrapper</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Obsidian's resolved tags, links, frontmatter</th>
+                <td class="mine y">Live metadata cache</td>
+                <td class="n">Re-parsed from disk</td>
+                <td class="n">Whatever this plugin returns</td>
+              </tr>
+              <tr>
+                <th scope="row">Writes seen by the running app</th>
+                <td class="mine y">Written through Obsidian's vault API</td>
+                <td class="n">Written behind Obsidian's back</td>
+                <td class="n">Whatever this plugin does</td>
+              </tr>
+              <tr>
+                <th scope="row">Single-section edits</th>
+                <td class="mine y">Heading, block, or field, with ifMatch</td>
+                <td class="n">Typically whole-file rewrite</td>
+                <td class="n">Only what it exposes of this plugin</td>
+              </tr>
+              <tr>
+                <th scope="row">Obsidian commands and UI</th>
+                <td class="mine y">List, execute, open notes</td>
+                <td class="n">Out of reach</td>
+                <td class="n">Only if it proxies them</td>
+              </tr>
+              <tr>
+                <th scope="row">Non-MCP clients</th>
+                <td class="mine y">curl, Shortcuts, browser extensions</td>
+                <td class="n">MCP only</td>
+                <td class="n">MCP only</td>
+              </tr>
+              <tr>
+                <th scope="row">Processes to install and run</th>
+                <td class="mine y">The plugin</td>
+                <td class="n">A server, kept up to date</td>
+                <td class="n">A server, plus this plugin</td>
+              </tr>
+              <tr>
+                <th scope="row">Usable with Obsidian closed</th>
+                <td class="mine n">No</td>
+                <td class="y">Yes</td>
+                <td class="n">No</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="foot-note">
+          Stated plainly: this is a door into a running Obsidian. That last row is the cost, and the
+          rest of the table is what it buys. Note also that the widely used third-party Obsidian MCP
+          servers are wrappers that call this plugin's REST API — if you are running one, you are
+          already running this.
+        </p>
+      </section>
+
+      <section id="start">
+        <div class="sec-head">
+          <p class="tag">Quick start</p>
+          <h2>From install to first request</h2>
+          <p>Enable the plugin, then open <strong>Settings → Local REST API</strong> to copy your API key.</p>
+        </div>
+
+        <div class="stack">
+          <div>
+            <h4 class="sub">1 · Check the server</h4>
+<pre class="block">curl -k https://127.0.0.1:27124/            <span class="cm"># status, no auth required</span></pre>
+          </div>
+          <div>
+            <h4 class="sub">2 · Read something</h4>
+<pre class="block">curl -k -H <span class="st">"Authorization: Bearer $KEY"</span> \
+  https://127.0.0.1:27124/vault/Projects/API.md/heading/Log</pre>
+          </div>
+          <div>
+            <h4 class="sub">3 · Connect an agent</h4>
+<pre class="block">claude mcp add --transport http obsidian https://127.0.0.1:27124/mcp/ \
+  --header <span class="st">"Authorization: Bearer $KEY"</span>
+
+<span class="cm"># Cursor, Claude Desktop, and any other Streamable HTTP client
+# use the same URL and the same header.</span></pre>
+          </div>
+        </div>
+      </section>
+
+      <section id="extensions">
+        <div class="sec-head">
+          <p class="tag">Extensions</p>
+          <h2>Other plugins can add to it</h2>
+          <p>
+            A plugin can register authenticated routes, public routes, and MCP tools on this server.
+            Install the published types as a dev dependency and the entire host surface is checked at
+            compile time — the declarations are generated from the plugin's own source, so they
+            cannot drift from what is actually running.
+          </p>
+        </div>
+
+        <div class="two">
+          <div>
+            <h4 class="sub">Install</h4>
+<pre class="block">npm install --save-dev obsidian-local-rest-api</pre>
+          </div>
+          <div>
+            <h4 class="sub">Use</h4>
+<pre class="block">import { getAPI } from <span class="st">"obsidian-local-rest-api"</span>;
+
+const api = getAPI(this.app, this.manifest, <span class="kw">2</span>);
+api?.addRoute(<span class="st">"/mine/"</span>).get(handler);</pre>
+          </div>
+        </div>
+        <p class="foot-note">
+          <a href="https://github.com/coddingtonbear/obsidian-local-rest-api/wiki/Adding-your-own-API-Routes-via-an-Extension">Extension guide →</a>
+        </p>
+      </section>
+
+      <section id="faq">
+        <div class="sec-head">
+          <p class="tag">Questions</p>
+          <h2>Before you install</h2>
+        </div>
+
+        <details open>
+          <summary>Does Obsidian need to be running?</summary>
+          <p>Yes. Everything the plugin offers beyond plain file access — the metadata cache, the active file, commands, Obsidian's own search — exists only inside a running app.</p>
+        </details>
+        <details>
+          <summary>How exposed is the server?</summary>
+          <p>It binds to 127.0.0.1 by default, and every route except the status check requires a bearer API key. The certificate is generated on your machine. The plain-HTTP port is off unless you enable it.</p>
+        </details>
+        <details>
+          <summary>Why the certificate warning?</summary>
+          <p>The certificate is self-signed, because it is issued locally for a loopback address. Trust it from <code>https://127.0.0.1:27124/obsidian-local-rest-api.crt</code>, pass it to your client directly, or use the optional plain-HTTP port.</p>
+        </details>
+        <details>
+          <summary>Does it work on mobile?</summary>
+          <p>No — desktop only. The plugin needs Node's TLS and HTTP server APIs, which Obsidian's mobile runtime does not provide.</p>
+        </details>
+        <details>
+          <summary>What does it cost?</summary>
+          <p>Nothing. MIT licensed, open source, installed from Obsidian's community plugin browser.</p>
+        </details>
+      </section>
+    </div>
+  </div>
+
+  <div class="closing">
+    <div class="shell">
+      <div>
+        <h2>Read the spec. Then read your vault.</h2>
+        <p>The interactive reference documents every route, parameter, and response — and it is generated from the same specification the plugin serves at runtime.</p>
+      </div>
+      <div class="actions" style="display:flex; gap:12px; flex-wrap:wrap;">
+        <a class="btn btn-solid" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install the plugin</a>
+        <a class="btn btn-line" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API reference</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer>
+  <div class="shell">
+    <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API documentation</a>
+    <a href="https://github.com/coddingtonbear/obsidian-local-rest-api">Source</a>
+    <a href="https://community.obsidian.md/plugins/obsidian-local-rest-api/">Community plugin page</a>
+    <a href="https://github.com/coddingtonbear/obsidian-local-rest-api/issues">Issues</a>
+    <span class="rights">MIT · Adam Coddington</span>
+  </div>
+</footer>
+
+<script>
+/* Mark the contents entry for whichever section is currently in view. */
+(function () {
+  var links = Array.prototype.slice.call(document.querySelectorAll('.rail a'));
+  var sections = links
+    .map(function (a) { return document.querySelector(a.getAttribute('href')); })
+    .filter(Boolean);
+  if (!('IntersectionObserver' in window) || !sections.length) return;
+
+  var observer = new IntersectionObserver(function (entries) {
+    entries.forEach(function (entry) {
+      if (!entry.isIntersecting) return;
+      links.forEach(function (a) {
+        a.setAttribute('aria-current', String(a.getAttribute('href') === '#' + entry.target.id));
+      });
+    });
+  }, { rootMargin: '-84px 0px -70% 0px' });
+
+  sections.forEach(function (s) { observer.observe(s); });
+})();
+</script>
+
+</body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Marketing site candidates — Local REST API with MCP</title>
+<meta name="robots" content="noindex">
+<link rel="icon" type="image/png" href="../favicon-32x32.png" sizes="32x32">
+<style>
+:root {
+  --paper: #f5f6f8; --card: #fff; --rule: #dde2e8; --ink: #18202a; --ink-2: #4a5765; --muted: #798694; --accent: #2f5d50;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color-scheme: light;
+}
+@media (prefers-color-scheme: dark) {
+  :root { --paper: #12161b; --card: #191e25; --rule: #2a323b; --ink: #e6ebf1; --ink-2: #aab4c0; --muted: #7b8794; --accent: #6cc7ad; color-scheme: dark; }
+}
+:root[data-theme="dark"] { --paper: #12161b; --card: #191e25; --rule: #2a323b; --ink: #e6ebf1; --ink-2: #aab4c0; --muted: #7b8794; --accent: #6cc7ad; color-scheme: dark; }
+:root[data-theme="light"] { --paper: #f5f6f8; --card: #fff; --rule: #dde2e8; --ink: #18202a; --ink-2: #4a5765; --muted: #798694; --accent: #2f5d50; color-scheme: light; }
+*, *::before, *::after { box-sizing: border-box; }
+body { margin: 0; background: var(--paper); color: var(--ink); font-family: var(--sans); font-size: 16.5px; line-height: 1.65; }
+.wrap { width: min(100% - 40px, 760px); margin: 0 auto; padding: 72px 0 88px; }
+h1 { margin: 0; font-size: 30px; letter-spacing: -0.02em; text-wrap: balance; }
+.tag { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; }
+p.intro { margin: 16px 0 0; color: var(--ink-2); }
+ul { list-style: none; margin: 36px 0 0; padding: 0; display: grid; gap: 14px; }
+li a { display: block; text-decoration: none; color: inherit; background: var(--card); border: 1px solid var(--rule); border-radius: 10px; padding: 20px 22px; }
+li a:hover { border-color: var(--accent); }
+li h2 { margin: 0; font-size: 18.5px; letter-spacing: -0.01em; }
+li h2 span { font-family: var(--mono); font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-left: 10px; }
+li p { margin: 8px 0 0; color: var(--ink-2); font-size: 15.4px; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--rule); font-size: 14.5px; color: var(--muted); }
+footer a { color: var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="tag">Candidates · not the published site</p>
+  <h1>Three marketing site directions</h1>
+  <p class="intro">
+    Same facts and same calls to action in each; the difference is who they are pitched at and how
+    they argue. Pick one, and it gets promoted to the site root — see
+    <code>docs/site/README.md</code> for how that is done without breaking the existing docs URL.
+  </p>
+
+  <ul>
+    <li>
+      <a href="./terminal/">
+        <h2>The wire <span>terminal</span></h2>
+        <p>Dark and developer-facing, built around a live request/response transcript. Argues that the API is concrete and immediate. Modelled on obsidian.md and make.md.</p>
+      </a>
+    </li>
+    <li>
+      <a href="./datasheet/">
+        <h2>The datasheet <span>datasheet</span></h2>
+        <p>Light, dense, and reference-like: a spec block, a contents rail, and the full endpoint matrix on the page. Argues that the thing is thoroughly documented. Modelled on the docs-style plugin sites.</p>
+      </a>
+    </li>
+    <li>
+      <a href="./conversation/">
+        <h2>The exchange <span>conversation</span></h2>
+        <p>Editorial and agent-facing, built around what an agent actually does to a vault. Argues from outcomes rather than endpoints. Modelled on Copilot for Obsidian and Smart Connections.</p>
+      </a>
+    </li>
+  </ul>
+
+  <footer>
+    The published interactive API reference stays where it is:
+    <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">coddingtonbear.github.io/obsidian-local-rest-api</a>.
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/site/terminal/index.html
+++ b/docs/site/terminal/index.html
@@ -1,0 +1,756 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Local REST API with MCP for Obsidian — your vault, over HTTP</title>
+<meta name="description" content="A secure REST API and Model Context Protocol server that runs inside Obsidian. Give scripts, browser extensions, and AI agents a direct, authenticated line into your vault.">
+<link rel="icon" type="image/png" href="../../favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="../../favicon-16x16.png" sizes="16x16">
+<style>
+/* ---------------------------------------------------------------------------
+   Direction: "the wire". The subject is an HTTP exchange on loopback, so the
+   page is built out of request/response pairs. Ground is a deep violet-black
+   borrowed from Obsidian's own world; the signal colour is apricot, so the
+   thing that moves (a request leaving, a response arriving) is the only warm
+   element on the page. Single-theme by choice — this is a console, not a
+   document, and it stays dark in both viewer themes.
+   --------------------------------------------------------------------------- */
+:root {
+  color-scheme: dark;
+  --ground: #0d0a16;
+  --ground-2: #120e1e;
+  --panel: #171227;
+  --panel-2: #1d1731;
+  --line: #2b2444;
+  --line-soft: #221c39;
+  --ink: #ece8f8;
+  --ink-2: #b9b1d6;
+  --muted: #8a82ab;
+  --signal: #ffb273;
+  --signal-dim: #cf8a52;
+  --violet: #a78bfa;
+  --ok: #79dfae;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", "Cascadia Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --measure: 62ch;
+  --shell: 1180px;
+  --r: 10px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ground);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* A faint beam behind the hero: the only gradient on the page. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: -30vh 0 auto 0;
+  height: 90vh;
+  background:
+    radial-gradient(60% 55% at 22% 30%, rgba(167,139,250,.16), transparent 70%),
+    radial-gradient(45% 45% at 78% 12%, rgba(255,178,115,.10), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.shell { width: min(100% - 48px, var(--shell)); margin-inline: auto; }
+main, header, footer { position: relative; z-index: 1; }
+
+a { color: var(--signal); text-decoration-color: color-mix(in srgb, var(--signal) 40%, transparent); text-underline-offset: 3px; }
+a:hover { text-decoration-color: currentColor; }
+:focus-visible { outline: 2px solid var(--signal); outline-offset: 3px; border-radius: 4px; }
+
+h1, h2, h3 { text-wrap: balance; margin: 0; letter-spacing: -0.022em; line-height: 1.1; }
+p { margin: 0; }
+
+/* --- structural label: every section announces itself like a header line --- */
+.label {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.label::after { content: ""; flex: 1; height: 1px; background: var(--line-soft); }
+
+/* --------------------------------- nav ---------------------------------- */
+.nav {
+  position: sticky; top: 0; z-index: 30;
+  backdrop-filter: blur(14px);
+  background: color-mix(in srgb, var(--ground) 82%, transparent);
+  border-bottom: 1px solid var(--line-soft);
+}
+.nav .shell { display: flex; align-items: center; gap: 24px; height: 62px; }
+.wordmark {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 14px; font-weight: 600;
+  color: var(--ink); text-decoration: none; letter-spacing: -.01em;
+  margin-right: auto;
+}
+.wordmark .braces { color: var(--signal); }
+.nav-links { display: flex; align-items: center; gap: 22px; }
+.nav-links a { color: var(--ink-2); text-decoration: none; font-size: 14.5px; }
+.nav-links a:hover { color: var(--ink); }
+@media (max-width: 720px) { .nav-links .hide-sm { display: none; } }
+
+/* --------------------------------- buttons ------------------------------- */
+.btn {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 11px 18px; border-radius: var(--r);
+  font-size: 15px; font-weight: 600; text-decoration: none;
+  border: 1px solid transparent; white-space: nowrap;
+  transition: transform .12s ease, background-color .12s ease, border-color .12s ease;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--signal); color: #2a1508; }
+.btn-primary:hover { background: #ffc493; }
+.btn-ghost { border-color: var(--line); color: var(--ink); background: color-mix(in srgb, var(--panel) 70%, transparent); }
+.btn-ghost:hover { border-color: var(--violet); color: #fff; }
+
+/* ---------------------------------- hero --------------------------------- */
+.hero .shell {
+  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 56px; align-items: center;
+  padding: 88px 0 76px;
+}
+@media (max-width: 940px) {
+  .hero .shell { grid-template-columns: 1fr; gap: 40px; padding: 56px 0 48px; }
+}
+.eyebrow {
+  font-family: var(--mono); font-size: 12px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--violet); margin-bottom: 22px;
+}
+h1 { font-size: clamp(40px, 6.2vw, 66px); font-weight: 700; letter-spacing: -0.035em; }
+h1 .em { color: var(--signal); }
+.hero p.lede {
+  margin-top: 22px; max-width: var(--measure);
+  font-size: clamp(17px, 1.5vw, 19.5px); color: var(--ink-2);
+}
+.hero-cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
+.hero-note { margin-top: 18px; font-size: 13.5px; color: var(--muted); font-family: var(--mono); }
+
+/* -------------------------- the transcript panel ------------------------- */
+.term {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 30px 70px -30px rgba(0,0,0,.9);
+}
+.term-bar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 11px 14px; border-bottom: 1px solid var(--line-soft);
+  background: var(--panel-2);
+  font-family: var(--mono); font-size: 12px; color: var(--muted);
+}
+.dot { width: 9px; height: 9px; border-radius: 50%; background: var(--line); }
+.term-bar .host { margin-left: 6px; }
+.term-body {
+  margin: 0; padding: 18px 18px 22px;
+  font-family: var(--mono); font-size: 13.2px; line-height: 1.75;
+  white-space: pre-wrap; word-break: break-word;
+  min-height: 340px;
+}
+.term-body .c-req { color: var(--signal); }
+.term-body .c-res { color: var(--ok); }
+.term-body .c-dim { color: var(--muted); }
+.term-body .c-key { color: var(--violet); }
+.term-body .c-str { color: var(--ink); }
+.caret {
+  display: inline-block; width: 8px; height: 1.05em; vertical-align: -2px;
+  background: var(--signal); animation: blink 1.05s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ------------------------------ fact strip -------------------------------- */
+.facts { border-block: 1px solid var(--line-soft); background: var(--ground-2); }
+.facts .shell {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 1px; background: var(--line-soft);
+  width: min(100% - 48px, var(--shell));
+}
+.fact { background: var(--ground-2); padding: 26px 24px; }
+.fact dt { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); }
+.fact dd { margin: 8px 0 0; font-size: 15.5px; color: var(--ink); font-weight: 600; }
+.fact dd small { display: block; font-weight: 400; font-size: 13.5px; color: var(--muted); margin-top: 3px; }
+@media (max-width: 860px) { .facts .shell { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 460px) { .facts .shell { grid-template-columns: 1fr; } }
+
+/* -------------------------------- sections -------------------------------- */
+section { padding: 92px 0; }
+@media (max-width: 720px) { section { padding: 64px 0; } }
+.section-head { max-width: 720px; margin-bottom: 44px; }
+.section-head h2 { font-size: clamp(28px, 3.4vw, 40px); font-weight: 700; margin-top: 20px; }
+.section-head p { margin-top: 16px; color: var(--ink-2); max-width: var(--measure); }
+
+/* exchange cards — the recurring device */
+.exchanges { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+@media (max-width: 860px) { .exchanges { grid-template-columns: 1fr; } }
+.ex {
+  border: 1px solid var(--line-soft); border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 60%, transparent);
+  padding: 22px 22px 20px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.ex h3 { font-size: 18px; font-weight: 650; }
+.ex p { color: var(--ink-2); font-size: 15px; }
+.ex .wire {
+  font-family: var(--mono); font-size: 12.6px; line-height: 1.7;
+  border-top: 1px dashed var(--line); padding-top: 12px; margin-top: auto;
+  color: var(--muted); overflow-x: auto;
+}
+.ex .wire b { font-weight: 500; color: var(--signal); }
+.ex .wire i { font-style: normal; color: var(--ok); }
+
+/* patch showcase */
+.patch { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 22px; align-items: stretch; }
+@media (max-width: 860px) { .patch { grid-template-columns: 1fr; } }
+.pane { border: 1px solid var(--line); border-radius: 12px; background: var(--panel); overflow: hidden; display: flex; flex-direction: column; }
+.pane-head {
+  padding: 10px 14px; border-bottom: 1px solid var(--line-soft); background: var(--panel-2);
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted);
+}
+.pane pre { margin: 0; padding: 16px; font-family: var(--mono); font-size: 13px; line-height: 1.7; overflow-x: auto; }
+.pane .add { color: var(--ok); }
+.pane .untouched { color: var(--muted); }
+
+/* comparison table */
+.table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; background: color-mix(in srgb, var(--panel) 55%, transparent); }
+table { border-collapse: collapse; width: 100%; min-width: 720px; font-size: 14.6px; }
+th, td { text-align: left; padding: 14px 18px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+thead th {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--muted); font-weight: 500; background: var(--panel-2);
+}
+thead th.mine { color: var(--signal); }
+tbody th { font-weight: 500; color: var(--ink-2); }
+tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
+td.yes { color: var(--ok); }
+td.no { color: var(--muted); }
+td.mine { background: color-mix(in srgb, var(--signal) 6%, transparent); }
+.table-foot { margin-top: 16px; font-size: 13.6px; color: var(--muted); max-width: var(--measure); }
+
+/* quick start tabs */
+.tabs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.tab {
+  font-family: var(--mono); font-size: 12.5px; letter-spacing: .06em;
+  padding: 8px 14px; border-radius: 999px; cursor: pointer;
+  border: 1px solid var(--line); background: transparent; color: var(--ink-2);
+}
+.tab[aria-selected="true"] { border-color: var(--signal); color: var(--signal); background: color-mix(in srgb, var(--signal) 10%, transparent); }
+.panel-code { border: 1px solid var(--line); border-radius: 12px; background: var(--panel); overflow: hidden; }
+.panel-code pre { margin: 0; padding: 20px; overflow-x: auto; font-family: var(--mono); font-size: 13.2px; line-height: 1.8; }
+.panel-code .cm { color: var(--muted); }
+.panel-code .fl { color: var(--violet); }
+.panel-code .st { color: var(--ok); }
+[hidden] { display: none !important; }
+
+/* extension + faq */
+.two-col { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 48px; align-items: start; }
+@media (max-width: 860px) { .two-col { grid-template-columns: 1fr; gap: 32px; } }
+.faq { display: grid; gap: 2px; border: 1px solid var(--line-soft); border-radius: 12px; overflow: hidden; }
+details { background: color-mix(in srgb, var(--panel) 55%, transparent); border-bottom: 1px solid var(--line-soft); }
+details:last-of-type { border-bottom: 0; }
+summary { cursor: pointer; padding: 17px 20px; font-weight: 600; font-size: 15.5px; list-style: none; display: flex; gap: 12px; align-items: baseline; }
+summary::-webkit-details-marker { display: none; }
+summary::before { content: "+"; font-family: var(--mono); color: var(--signal); }
+details[open] summary::before { content: "–"; }
+details p { padding: 0 20px 18px 41px; color: var(--ink-2); font-size: 15px; max-width: var(--measure); }
+
+/* closing call to action */
+.close { text-align: center; padding: 96px 0 104px; border-top: 1px solid var(--line-soft); }
+.close h2 { font-size: clamp(30px, 4vw, 44px); font-weight: 700; }
+.close p { margin: 18px auto 0; max-width: 56ch; color: var(--ink-2); }
+.close .hero-cta { justify-content: center; }
+
+footer { border-top: 1px solid var(--line-soft); background: var(--ground-2); padding: 40px 0 56px; }
+footer .shell { display: flex; flex-wrap: wrap; gap: 20px 44px; align-items: baseline; }
+footer .col { display: flex; gap: 20px; flex-wrap: wrap; }
+footer a { color: var(--ink-2); text-decoration: none; font-size: 14.5px; }
+footer a:hover { color: var(--signal); }
+footer .credit { margin-left: auto; color: var(--muted); font-size: 13.5px; font-family: var(--mono); }
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: .001ms !important; transition-duration: .001ms !important; }
+}
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="shell">
+    <a class="wordmark" href="#top"><span class="braces">{&hairsp;}</span> Local REST API <span style="color:var(--muted)">with MCP</span></a>
+    <nav class="nav-links">
+      <a href="#capabilities" class="hide-sm">Capabilities</a>
+      <a href="#compare" class="hide-sm">Compare</a>
+      <a href="#start">Quick start</a>
+      <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API docs</a>
+      <a href="https://github.com/coddingtonbear/obsidian-local-rest-api" class="hide-sm">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main id="top">
+
+  <section class="hero">
+    <div class="shell">
+      <div>
+        <p class="eyebrow">Obsidian community plugin · MIT licensed</p>
+        <h1>Your vault<br>has an <span class="em">API</span>.</h1>
+        <p class="lede">
+          A secure REST API <em>and</em> a Model Context Protocol server, running inside Obsidian
+          itself. Scripts, browser extensions, and AI agents get a direct, authenticated line into
+          your notes — with Obsidian's own metadata, search, and commands behind it.
+        </p>
+        <div class="hero-cta">
+          <a class="btn btn-primary" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install the plugin</a>
+          <a class="btn btn-ghost" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Read the API docs</a>
+        </div>
+        <p class="hero-note">Loopback only · bearer-token auth · nothing leaves your machine</p>
+      </div>
+
+      <div class="term" aria-label="An example request and response">
+        <div class="term-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="host">127.0.0.1:27124</span>
+        </div>
+        <pre class="term-body" id="transcript"></pre>
+      </div>
+    </div>
+  </section>
+
+  <div class="facts">
+    <dl class="shell">
+      <div class="fact"><dt>Two interfaces</dt><dd>REST + MCP<small>One server, one API key</small></dd></div>
+      <div class="fact"><dt>MCP tools</dt><dd>16 built in<small>No bridge process to run</small></dd></div>
+      <div class="fact"><dt>Edits</dt><dd>Section-level<small>Heading, block, or frontmatter</small></dd></div>
+      <div class="fact"><dt>Reach</dt><dd>Loopback only<small>HTTPS on 27124 by default</small></dd></div>
+    </dl>
+  </div>
+
+  <section id="capabilities">
+    <div class="shell">
+      <div class="section-head">
+        <p class="label">Capabilities</p>
+        <h2>Everything is a request. Everything comes back.</h2>
+        <p>
+          The same capabilities are exposed twice — as HTTP endpoints for anything that can make a
+          request, and as MCP tools for anything that speaks to a model. Learn one, and you know
+          the other.
+        </p>
+      </div>
+
+      <div class="exchanges">
+        <article class="ex">
+          <h3>Read and write any file</h3>
+          <p>Full CRUD across the vault, including binary attachments, directory listings, and the note that happens to be open in front of you.</p>
+          <div class="wire"><b>GET</b> /vault/notes/daily.md<br><i>200</i> — text/markdown</div>
+        </article>
+
+        <article class="ex">
+          <h3>Edit one section, not the file</h3>
+          <p>Target a heading, block reference, or frontmatter key and append, prepend, replace, delete, or move just that part. The rest of the note is never rewritten.</p>
+          <div class="wire"><b>PATCH</b> /vault/daily.md<br><span>{"targetType":"heading","operation":"append"}</span><br><i>200</i> — section updated</div>
+        </article>
+
+        <article class="ex">
+          <h3>Search the way Obsidian does</h3>
+          <p>Obsidian's own fuzzy search with scored snippets, or a JsonLogic expression evaluated against every note's frontmatter, tags, path, and content.</p>
+          <div class="wire"><b>POST</b> /search/<br><span>{"in": ["reading", {"var": "tags"}]}</span><br><i>200</i> — matching notes</div>
+        </article>
+
+        <article class="ex">
+          <h3>Drive the app, not just the files</h3>
+          <p>List and execute any Obsidian command exactly as the command palette would, open a note in the UI, or read every tag in the vault with its usage count.</p>
+          <div class="wire"><b>POST</b> /commands/graph:open/<br><i>204</i> — executed in Obsidian</div>
+        </article>
+
+        <article class="ex">
+          <h3>Connect an agent in one line</h3>
+          <p>A Streamable HTTP MCP server at <code>/mcp/</code> with sixteen tools covering the vault, search, the active file, and the command palette.</p>
+          <div class="wire"><b>POST</b> /mcp/<br><i>tools</i> — vault_patch, search_query, …</div>
+        </article>
+
+        <article class="ex">
+          <h3>Extend it from your own plugin</h3>
+          <p>Other plugins register authenticated routes and MCP tools against this server. Install the typed package and the whole surface is checked at compile time.</p>
+          <div class="wire"><b>npm</b> i -D obsidian-local-rest-api<br><i>ts</i> — getAPI(app, manifest, 2)</div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section style="background:var(--ground-2); border-block:1px solid var(--line-soft);">
+    <div class="shell">
+      <div class="section-head">
+        <p class="label">Surgical edits</p>
+        <h2>Append a line to a heading without touching the note around it.</h2>
+        <p>
+          Send an instruction — an operation, a scope, and a target — and the API applies it to
+          exactly that node. Heading levels in your content are rebased for you, whitespace is
+          handled for you, and an <code>ifMatch</code> token makes the edit conditional on the file
+          being unchanged since you read it.
+        </p>
+      </div>
+
+      <div class="patch">
+        <div class="pane">
+          <div class="pane-head">The instruction</div>
+<pre>{
+  "targetType": "heading",
+  "target": ["Log"],
+  "operation": "append",
+  "content": "- Shipped the release"
+}</pre>
+          <div class="pane-head" style="border-top:1px solid var(--line-soft); border-bottom:0;">Or, with nothing to escape</div>
+<pre><span class="untouched"># Target in the URL, operation in a header,
+# body is the raw payload.</span>
+curl -k -X PATCH \
+  -H "Operation: append" \
+  -H "Content-Type: text/markdown" \
+  --data "- Shipped the release" \
+  .../vault/daily.md/heading/Log</pre>
+        </div>
+        <div class="pane">
+          <div class="pane-head">daily.md — after</div>
+<pre><span class="untouched">---
+status: open
+---
+
+# Daily
+
+## Notes
+
+Nothing here changed.
+
+## Log
+
+- Reviewed the queue</span>
+<span class="add">- Shipped the release</span>
+<span class="untouched">
+## Tomorrow
+
+Also untouched.</span></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="compare">
+    <div class="shell">
+      <div class="section-head">
+        <p class="label">Compared with the alternatives</p>
+        <h2>The difference is that it runs <em>inside</em> Obsidian.</h2>
+        <p>
+          A server that reads your vault off disk sees a folder of text files. This one sees what
+          Obsidian sees: the resolved metadata cache, the active file, the command palette — and it
+          writes back through Obsidian's own vault API, so the running app never misses or clobbers
+          a change.
+        </p>
+      </div>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">&nbsp;</th>
+              <th scope="col" class="mine">This plugin</th>
+              <th scope="col">Filesystem MCP servers</th>
+              <th scope="col">Third-party REST wrappers</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Sees Obsidian's resolved tags, links, and frontmatter</th>
+              <td class="mine yes">Yes — the live metadata cache</td>
+              <td class="no">Re-parses the markdown itself</td>
+              <td class="no">Only by calling this plugin</td>
+            </tr>
+            <tr>
+              <th scope="row">Writes through Obsidian's vault API</th>
+              <td class="mine yes">Yes — the open app sees it at once</td>
+              <td class="no">Writes to disk behind Obsidian's back</td>
+              <td class="no">Only by calling this plugin</td>
+            </tr>
+            <tr>
+              <th scope="row">Edits a single heading, block, or field</th>
+              <td class="mine yes">Yes, with optimistic concurrency</td>
+              <td class="no">Usually rewrites the whole file</td>
+              <td class="no">Only by calling this plugin</td>
+            </tr>
+            <tr>
+              <th scope="row">Runs Obsidian commands and opens notes in the UI</th>
+              <td class="mine yes">Yes</td>
+              <td class="no">No — there is no app to drive</td>
+              <td class="no">Only by calling this plugin</td>
+            </tr>
+            <tr>
+              <th scope="row">Clients it serves</th>
+              <td class="mine yes">MCP clients <em>and</em> curl, Shortcuts, browser extensions</td>
+              <td class="no">MCP clients only</td>
+              <td class="no">MCP clients only</td>
+            </tr>
+            <tr>
+              <th scope="row">Extra process to install and keep running</th>
+              <td class="mine yes">None — it is the plugin</td>
+              <td class="no">Yes, a separate server</td>
+              <td class="no">Yes, plus this plugin underneath</td>
+            </tr>
+            <tr>
+              <th scope="row">Works while Obsidian is closed</th>
+              <td class="mine no">No</td>
+              <td class="yes">Yes</td>
+              <td class="no">No</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-foot">
+        The last row is the honest trade-off: this plugin is a door into a running Obsidian, not a
+        replacement for one. If you only ever want to read a folder of markdown while the app is
+        shut, a filesystem server is the simpler tool.
+      </p>
+    </div>
+  </section>
+
+  <section id="start" style="background:var(--ground-2); border-block:1px solid var(--line-soft);">
+    <div class="shell">
+      <div class="section-head">
+        <p class="label">Quick start</p>
+        <h2>Install, copy the key, make a request.</h2>
+        <p>
+          Enable the plugin and open <strong>Settings → Local REST API</strong> for your API key.
+          Everything below uses it as a bearer token.
+        </p>
+      </div>
+
+      <div class="tabs" role="tablist" aria-label="Quick start examples">
+        <button class="tab" role="tab" aria-selected="true" aria-controls="p-curl" id="t-curl">curl</button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="p-cc" id="t-cc">Claude Code</button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="p-cd" id="t-cd">Claude Desktop</button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="p-cur" id="t-cur">Cursor</button>
+      </div>
+
+      <div class="panel-code">
+        <div role="tabpanel" id="p-curl" aria-labelledby="t-curl">
+<pre><span class="cm"># Read a note</span>
+curl -k -H <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span> \
+  https://127.0.0.1:27124/vault/path/to/note.md
+
+<span class="cm"># Append a line under a heading — no JSON escaping needed</span>
+curl -k -X PATCH \
+  -H <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span> \
+  -H <span class="st">"Operation: append"</span> \
+  -H <span class="st">"Content-Type: text/markdown"</span> \
+  --data <span class="st">"- One more thing"</span> \
+  https://127.0.0.1:27124/vault/notes/daily.md/heading/Log</pre>
+        </div>
+
+        <div role="tabpanel" id="p-cc" aria-labelledby="t-cc" hidden>
+<pre>claude mcp add --transport http obsidian https://127.0.0.1:27124/mcp/ \
+  <span class="fl">--header</span> <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span></pre>
+        </div>
+
+        <div role="tabpanel" id="p-cd" aria-labelledby="t-cd" hidden>
+<pre><span class="cm">// claude_desktop_config.json</span>
+{
+  <span class="fl">"mcpServers"</span>: {
+    <span class="fl">"obsidian"</span>: {
+      <span class="fl">"command"</span>: <span class="st">"npx"</span>,
+      <span class="fl">"args"</span>: [
+        <span class="st">"mcp-remote@latest"</span>,
+        <span class="st">"https://127.0.0.1:27124/mcp/"</span>,
+        <span class="st">"--header"</span>,
+        <span class="st">"Authorization: Bearer &lt;your-api-key&gt;"</span>
+      ]
+    }
+  }
+}</pre>
+        </div>
+
+        <div role="tabpanel" id="p-cur" aria-labelledby="t-cur" hidden>
+<pre><span class="cm">// ~/.cursor/mcp.json</span>
+{
+  <span class="fl">"mcpServers"</span>: {
+    <span class="fl">"obsidian"</span>: {
+      <span class="fl">"url"</span>: <span class="st">"https://127.0.0.1:27124/mcp/"</span>,
+      <span class="fl">"headers"</span>: {
+        <span class="fl">"Authorization"</span>: <span class="st">"Bearer &lt;your-api-key&gt;"</span>
+      }
+    }
+  }
+}</pre>
+        </div>
+      </div>
+      <p class="table-foot">
+        Every endpoint, parameter, and response shape is documented in the
+        <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">interactive API reference</a> —
+        generated from the same OpenAPI spec the plugin serves to MCP clients at runtime.
+      </p>
+    </div>
+  </section>
+
+  <section>
+    <div class="shell two-col">
+      <div>
+        <p class="label">Questions</p>
+        <h2 style="font-size:clamp(26px,3vw,34px); font-weight:700; margin:20px 0 24px;">Before you install</h2>
+        <div class="faq">
+          <details open>
+            <summary>Does Obsidian have to be running?</summary>
+            <p>Yes — and that is the point. Running inside Obsidian is what gives the API the live metadata cache, the active file, and the command palette. If you need vault access with the app closed, a filesystem tool is a better fit.</p>
+          </details>
+          <details>
+            <summary>How exposed is this?</summary>
+            <p>The server binds to 127.0.0.1 by default and every route but the status check requires a bearer API key. HTTPS uses a certificate generated on your machine; the plain-HTTP port is off unless you turn it on.</p>
+          </details>
+          <details>
+            <summary>Do I still need a third-party MCP server?</summary>
+            <p>No. Several exist, and the popular ones are wrappers that call this plugin's REST API anyway. The MCP server is built in, so there is nothing extra to install or keep running.</p>
+          </details>
+          <details>
+            <summary>What about the certificate warning?</summary>
+            <p>Trust the certificate from <code>https://127.0.0.1:27124/obsidian-local-rest-api.crt</code>, point your client at it directly, or enable the plain-HTTP port for clients that cannot be persuaded.</p>
+          </details>
+          <details>
+            <summary>Mobile?</summary>
+            <p>Desktop only. The plugin needs Node's TLS and HTTP server APIs, which Obsidian's mobile runtime does not provide.</p>
+          </details>
+        </div>
+      </div>
+
+      <div>
+        <p class="label">Extensions</p>
+        <h2 style="font-size:clamp(26px,3vw,34px); font-weight:700; margin:20px 0 20px;">Other plugins build on it</h2>
+        <p style="color:var(--ink-2); max-width:var(--measure);">
+          A plugin can register its own authenticated routes, public routes, and MCP tools on this
+          server — so a capability that belongs to your plugin ships with your plugin, and every
+          client that already has an API key can reach it.
+        </p>
+        <div class="panel-code" style="margin-top:24px;">
+<pre><span class="cm">// your plugin</span>
+import { getAPI } from <span class="st">"obsidian-local-rest-api"</span>;
+
+const api = getAPI(this.app, this.manifest, <span class="fl">2</span>);
+
+api?.addRoute(<span class="st">"/my-plugin/thing"</span>)
+   .get((req, res) =&gt; res.json({ ok: <span class="fl">true</span> }));</pre>
+        </div>
+        <p style="color:var(--muted); font-size:14px; margin-top:16px;">
+          The published types are generated from the plugin's own source, so they cannot drift from
+          what the host actually offers.
+          <a href="https://github.com/coddingtonbear/obsidian-local-rest-api/wiki/Adding-your-own-API-Routes-via-an-Extension">Read the extension guide →</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="close">
+    <div class="shell">
+      <h2>Open the door to your vault.</h2>
+      <p>Free and open source. Install from Obsidian's community plugin browser, or read the full API reference first.</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://obsidian.md/plugins?id=obsidian-local-rest-api">Install the plugin</a>
+        <a class="btn btn-ghost" href="https://coddingtonbear.github.io/obsidian-local-rest-api/">Interactive API docs</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <div class="shell">
+    <div class="col">
+      <a href="https://coddingtonbear.github.io/obsidian-local-rest-api/">API documentation</a>
+      <a href="https://github.com/coddingtonbear/obsidian-local-rest-api">GitHub</a>
+      <a href="https://community.obsidian.md/plugins/obsidian-local-rest-api/">Community plugin page</a>
+      <a href="https://github.com/coddingtonbear/obsidian-local-rest-api/wiki/Adding-your-own-API-Routes-via-an-Extension">Build an extension</a>
+    </div>
+    <div class="credit">MIT · by Adam Coddington</div>
+  </div>
+</footer>
+
+<script>
+(function () {
+  /* ---- tabs ---- */
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  tabs.forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      tabs.forEach(function (t) {
+        var selected = t === tab;
+        t.setAttribute('aria-selected', String(selected));
+        document.getElementById(t.getAttribute('aria-controls')).hidden = !selected;
+      });
+    });
+  });
+
+  /* ---- hero transcript ----
+     One orchestrated moment: a request goes out, a response comes back. Anyone
+     who has asked for reduced motion gets the finished transcript immediately. */
+  var target = document.getElementById('transcript');
+  var lines = [
+    { cls: 'c-dim', text: '$ ' },
+    { cls: 'c-req', text: 'curl -H "Authorization: Bearer $KEY" \\\n' },
+    { cls: 'c-req', text: '     https://127.0.0.1:27124/vault/Projects/API.md\n\n' },
+    { cls: 'c-res', text: 'HTTP/1.1 200 OK\n' },
+    { cls: 'c-dim', text: 'Content-Type: text/markdown\n\n' },
+    { cls: 'c-str', text: '# API\n\n## Log\n\n- Reviewed the queue\n\n' },
+    { cls: 'c-dim', text: '$ ' },
+    { cls: 'c-req', text: 'curl -X PATCH -H "Operation: append" \\\n' },
+    { cls: 'c-req', text: '     -H "Content-Type: text/markdown" \\\n' },
+    { cls: 'c-req', text: '     --data "- Shipped the release" \\\n' },
+    { cls: 'c-req', text: '     .../vault/Projects/API.md/heading/Log\n\n' },
+    { cls: 'c-res', text: 'HTTP/1.1 200 OK  ' },
+    { cls: 'c-key', text: '# one heading changed, note intact\n' }
+  ];
+
+  function renderAll() {
+    target.textContent = '';
+    lines.forEach(function (line) { target.appendChild(span(line.cls, line.text)); });
+  }
+  function span(cls, text) {
+    var el = document.createElement('span');
+    el.className = cls;
+    el.textContent = text;
+    return el;
+  }
+
+  var reduced = window.matchMedia('(prefers-reduced-motion: reduce)');
+  if (reduced.matches) { renderAll(); return; }
+
+  var caret = document.createElement('span');
+  caret.className = 'caret';
+  target.appendChild(caret);
+
+  var li = 0, ci = 0, current = null;
+  function step() {
+    if (li >= lines.length) { caret.style.animation = 'none'; caret.style.opacity = '.35'; return; }
+    var line = lines[li];
+    if (ci === 0) { current = span(line.cls, ''); target.insertBefore(current, caret); }
+    /* Type in small chunks so a long transcript still resolves quickly. */
+    var chunk = line.text.slice(ci, ci + 3);
+    current.textContent += chunk;
+    ci += chunk.length;
+    var delay = 18;
+    if (ci >= line.text.length) { li += 1; ci = 0; delay = line.text.indexOf('\n\n') > -1 ? 260 : 90; }
+    setTimeout(step, delay);
+  }
+  setTimeout(step, 420);
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
The plugin has an interactive API reference, but nothing that explains to someone who hasn't already decided to use it what it does or why it beats the alternatives they're actually comparing it against. This adds three complete candidate marketing sites, meant to be compared in a browser and narrowed to one.

## Preview them live

Each is also published as a private preview page, so they can be compared without deploying anything:

| Candidate | Preview | Pitched at |
|---|---|---|
| `terminal/` — **the wire** | https://claude.ai/code/artifact/57ab4399-db31-4bf6-9b39-33a8f126f1e5 | Developers evaluating the REST API |
| `datasheet/` — **the datasheet** | https://claude.ai/code/artifact/670e1536-6e5f-4a74-8dda-bb3574ace774 | People who want proof it's documented |
| `conversation/` — **the exchange** | https://claude.ai/code/artifact/2d1a6b12-7d0c-451b-8f01-8afdc3af3fe5 | People connecting an AI client |

Locally: `npm run serve-docs`, then open `/site/` for a chooser page linking all three.

## What each one argues

All three carry the same facts, the same comparison table, and the same two calls to action — install, and the interactive API reference. They differ in reader and in argument:

- **terminal** — dark, mono-led, built around a live request/response transcript that types itself out in the hero. Argues the API is concrete and immediate. Modelled on obsidian.md and make.md.
- **datasheet** — light, serif headings on cool paper, a spec block, a sticky contents rail, and the full endpoint matrix on the page. Argues the thing is thoroughly documented. Modelled on the docs-style plugin sites (Templater, Tasks, Omnisearch).
- **conversation** — editorial, built around a person asking for something and the tool calls that land in the vault. Argues from outcomes rather than endpoints. Modelled on Copilot for Obsidian and Smart Connections.

## Why this doesn't put the docs URL at risk

The single real risk here is the published docs URL, so it is untouched:

- These ship under `docs/site/`, **not** at the Pages root. `https://coddingtonbear.github.io/obsidian-local-rest-api/` still serves the Elements viewer, byte for byte — this PR adds files and changes none.
- Nothing outside `docs/site/` is modified: no `src/`, no `docs/openapi.yaml`, no `docs/index.html`, no README. `git diff main --stat` is five new files and nothing else.
- Promotion to the root is deliberately *not* done here. `docs/site/README.md` documents the sequence for when a winner is picked, including leaving a redirect at the old root so the years-old docs URL — quoted in the README, the plugin's settings pages, and third-party documentation — keeps working.
- `deploy-docs.yml` uploads all of `docs/`, so these become reachable at `…/site/` on the next tag or a manual workflow dispatch. That is additive; no existing path changes.

## Marketing claims, and where they come from

Every claim is checked against the code rather than asserted:

- "Binds to 127.0.0.1", "HTTPS on 27124", "plain HTTP off by default" — `DefaultBindingHost` and `DEFAULT_SETTINGS` in `src/constants.ts`.
- "16 MCP tools", tool names, endpoint/method table — `src/mcpHandler.ts` and the README's API overview.
- "Writes go through Obsidian's vault API so the running app sees the change" — the behaviour added in ee35b93.
- "Desktop only", "1.13.1+" — `manifest.json`.

The comparison table includes the row where the alternatives win: a filesystem MCP server keeps working while Obsidian is closed, and this doesn't. Each page says so in prose underneath as well. There are no invented testimonials, download counts, user quotes, or third-party logos anywhere — the only social proof is the verifiable fact that popular third-party Obsidian MCP servers are wrappers around this plugin's REST API.

## Verification

- `npm test` — 377 passed, 6 suites, no changes to test surface (nothing under `src/` was touched).
- All five pages rendered headlessly in Chromium at 1440px, full-page, and inspected: hero, capability grids, comparison tables, code blocks, and footers.
- Both themes checked on the two dual-theme pages by forcing `data-theme="light"` and by OS-dark default. `terminal` is single-theme dark by design.
- Two real defects were found this way and fixed: `.top nav a` out-specified `.btn-solid`, making the nav install button's label invisible against its own fill (same collision latent in `datasheet`'s hover state), and a hero line wrapped a single word.

## Honest gaps

- Not viewed on a physical mobile device — layouts are responsive and were checked at narrow widths via media queries, but only rendered at desktop widths.
- Only rendered in Chromium; not checked in Safari or Firefox. The pages use no exotic CSS beyond `color-mix()` and `text-wrap: balance`, both of which degrade gracefully.
- The hero transcript animation in `terminal` was verified to complete and to be skipped under `prefers-reduced-motion`, but not timed against a slow device.
- Copy has had one editing pass, not several. If a direction is chosen, it's worth a read-through with fresh eyes before it goes to the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)