### PR TITLE
Serve MCP protocol revision 2026-07-28 on SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Any MCP client that supports the Streamable HTTP transport can connect to `https
 | `/tags/` | GET | List all tags with usage counts |
 | `/open/{path}` | POST | Open a file in the Obsidian UI |
 | `/` | GET | Server status and authentication check |
-| `/mcp/` | POST | MCP (Model Context Protocol) server — connect AI agents directly to your vault |
+| `/mcp/` | GET POST | MCP (Model Context Protocol) server — connect AI agents directly to your vault |
 
 For full request/response details, see the [interactive docs](https://coddingtonbear.github.io/obsidian-local-rest-api/).
 
@@ -292,7 +292,7 @@ The endpoint serves the `2026-07-28` revision plus the legacy revisions from `20
 
 The `2026-07-28` revision is stateless: there is no `initialize` handshake and no session, so the plugin neither issues nor reads the `Mcp-Session-Id` header. Each request carries its own protocol version and client identity in `params._meta`, repeats them in the `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers, and is answered on its own. Clients can call `server/discover` to learn the supported revisions and capabilities up front.
 
-Clients that still open with an `initialize` request keep working unchanged — they are served the legacy revision they negotiate, statelessly. The `GET` stream and `DELETE` session-termination operations those revisions defined are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
+Clients that still open with an `initialize` request keep working unchanged — they are served the legacy revision they negotiate, sessions and all: the handshake returns an `Mcp-Session-Id`, `GET /mcp/` opens that session's notification stream, and `DELETE /mcp/` ends it. Sessions exist only on this path, and they are what keeps the handshake's `listChanged` capabilities honest: when another plugin registers or removes an MCP tool, every live legacy session is notified, while modern clients hear about it on a `subscriptions/listen` stream.
 
 ### Connecting a client
 

--- a/README.md
+++ b/README.md
@@ -288,11 +288,11 @@ The plugin includes a built-in MCP server at `/mcp/` so AI agents and MCP-compat
 
 ### Protocol revisions
 
-The endpoint serves the `2026-07-28` revision plus the legacy revisions from `2024-10-07` through `2025-11-25`, choosing per request, so new and old clients can share it at the same time.
+The endpoint serves the `2026-07-28` revision plus the sessionful revisions from `2024-10-07` through `2025-11-25`, choosing per request, so clients on either can share it.
 
 The `2026-07-28` revision is stateless: there is no `initialize` handshake and no session, so the plugin neither issues nor reads the `Mcp-Session-Id` header. Each request carries its own protocol version and client identity in `params._meta`, repeats them in the `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers, and is answered on its own. Clients can call `server/discover` to learn the supported revisions and capabilities up front.
 
-Clients that still open with an `initialize` request keep working unchanged — they are served the legacy revision they negotiate, sessions and all: the handshake returns an `Mcp-Session-Id`, `GET /mcp/` opens that session's notification stream, and `DELETE /mcp/` ends it. Sessions exist only on this path, and they are what keeps the handshake's `listChanged` capabilities honest: when another plugin registers or removes an MCP tool, every live legacy session is notified, while modern clients hear about it on a `subscriptions/listen` stream.
+Clients that open with an `initialize` request are served the sessionful revision they negotiate: the handshake returns an `Mcp-Session-Id`, `GET /mcp/` opens that session's notification stream, and `DELETE /mcp/` ends it. Sessions exist only on this path, and they are what keeps the handshake's `listChanged` capabilities honest: when another plugin registers or removes an MCP tool, every live session is notified, while `2026-07-28` clients hear about it on a `subscriptions/listen` stream.
 
 ### Connecting a client
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Give your scripts, browser extensions, and AI agents a direct line into your Obs
 - [Targeting specific sections](#targeting-specific-sections)
 - [Searching](#searching)
 - [MCP (Model Context Protocol)](#mcp-model-context-protocol)
+  * [Protocol revisions](#protocol-revisions)
   * [Connecting a client](#connecting-a-client)
   * [Available tools](#available-tools)
   * [Available resources](#available-resources)
@@ -167,7 +168,7 @@ Any MCP client that supports the Streamable HTTP transport can connect to `https
 | `/tags/` | GET | List all tags with usage counts |
 | `/open/{path}` | POST | Open a file in the Obsidian UI |
 | `/` | GET | Server status and authentication check |
-| `/mcp/` | GET POST | MCP (Model Context Protocol) server — connect AI agents directly to your vault |
+| `/mcp/` | POST | MCP (Model Context Protocol) server — connect AI agents directly to your vault |
 
 For full request/response details, see the [interactive docs](https://coddingtonbear.github.io/obsidian-local-rest-api/).
 
@@ -284,6 +285,14 @@ curl -k -H "Authorization: Bearer <your-api-key>" \
 The plugin includes a built-in MCP server at `/mcp/` so AI agents and MCP-compatible clients can interact with your vault without hand-crafting HTTP requests.
 
 **Transport:** Streamable HTTP — API key authentication required.
+
+### Protocol revisions
+
+The endpoint serves the `2026-07-28` revision plus the legacy revisions from `2024-10-07` through `2025-11-25`, choosing per request, so new and old clients can share it at the same time.
+
+The `2026-07-28` revision is stateless: there is no `initialize` handshake and no session, so the plugin neither issues nor reads the `Mcp-Session-Id` header. Each request carries its own protocol version and client identity in `params._meta`, repeats them in the `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers, and is answered on its own. Clients can call `server/discover` to learn the supported revisions and capabilities up front.
+
+Clients that still open with an `initialize` request keep working unchanged — they are served the legacy revision they negotiate, statelessly. The `GET` stream and `DELETE` session-termination operations those revisions defined are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
 
 ### Connecting a client
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1361,7 +1361,7 @@ paths:
   /mcp/:
     get:
       description: |
-        Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the legacy protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.
+        Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the sessionful protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.
       parameters:
         - description: "Session ID returned by the server on initialization."
           in: "header"
@@ -1401,7 +1401,7 @@ paths:
                 "$ref": "#/components/schemas/Error"
           description: "Session not found."
       summary: |
-        Open a server-sent events stream for an existing legacy MCP session.
+        Open a server-sent events stream for an existing sessionful MCP session.
       tags:
         - "MCP"
     post:
@@ -1412,7 +1412,7 @@ paths:
         
         ## Protocol revisions
         
-        The endpoint serves the `2026-07-28` revision and, alongside it, the legacy revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
+        The endpoint serves the `2026-07-28` revision and, alongside it, the sessionful revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
         
         **`2026-07-28` (recommended).** Every request stands alone: there is no `initialize` handshake, and each request carries its own protocol version and client identity in `params._meta`:
         
@@ -1428,9 +1428,9 @@ paths:
         
         Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
         
-        **Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before — including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
+        **Sessionful revisions (`2024-10-07` through `2025-11-25`).** Clients that open with an `initialize` request are served the revision they negotiate, including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
         
-        Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live legacy session is told over its notification stream. Modern clients get the same news from a `subscriptions/listen` stream instead.
+        Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live session is told over its notification stream. `2026-07-28` clients get the same news from a `subscriptions/listen` stream instead.
         
         Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
         
@@ -1461,13 +1461,13 @@ paths:
         |---|---|
         | `obsidian://local-rest-api/openapi.yaml` | Full OpenAPI specification for this REST API |
       parameters:
-        - description: "Session ID returned by the server on initialization. A session operation of the legacy protocol revisions: omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there."
+        - description: "Session ID returned by the server on initialization. A session operation of the sessionful protocol revisions (`2024-10-07` through `2025-11-25`): omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there."
           in: "header"
           name: "Mcp-Session-Id"
           required: false
           schema:
             type: "string"
-        - description: "Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta[\"io.modelcontextprotocol/protocolVersion\"]`; on the legacy revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400."
+        - description: "Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta[\"io.modelcontextprotocol/protocolVersion\"]`; on the sessionful revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400."
           in: "header"
           name: "MCP-Protocol-Version"
           required: false
@@ -1585,10 +1585,10 @@ paths:
         required: true
       responses:
         "200":
-          description: "Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a legacy `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one."
+          description: "Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a sessionful-revision `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one."
           headers:
             Mcp-Session-Id:
-              description: "Session ID assigned by the server. Present only on a legacy `initialize` response."
+              description: "Session ID assigned by the server. Present only on a sessionful-revision `initialize` response."
               schema:
                 type: "string"
         "400":
@@ -1608,7 +1608,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-          description: "Session not found. The `Mcp-Session-Id` header names a legacy session that has ended; hand-shake again with `initialize`."
+          description: "Session not found. The `Mcp-Session-Id` header names a session that has ended; hand-shake again with `initialize`."
       summary: |
         Send a JSON-RPC 2.0 message to the MCP server.
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1359,58 +1359,33 @@ paths:
       tags:
         - "Commands"
   /mcp/:
-    get:
-      description: |
-        Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response.
-      parameters:
-        - description: "Session ID returned by the server on initialization."
-          in: "header"
-          name: "Mcp-Session-Id"
-          required: true
-          schema:
-            type: "string"
-        - description: "MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Required on all requests after initialization. Unrecognised values are rejected with 400."
-          in: "header"
-          name: "MCP-Protocol-Version"
-          required: false
-          schema:
-            type: "string"
-      responses:
-        "200":
-          content:
-            text/event-stream:
-              schema:
-                type: "string"
-          description: "SSE stream opened. The server pushes JSON-RPC messages as server-sent events."
-        "400":
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/Error"
-          description: "Unsupported MCP-Protocol-Version."
-        "401":
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/Error"
-          description: "API key required."
-        "404":
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/Error"
-          description: "Session not found."
-      summary: |
-        Open a server-sent events stream for an existing MCP session.
-      tags:
-        - "MCP"
     post:
       description: |
         Interact with this plugin's MCP server using the [Streamable HTTP transport](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http).
         
-        Point any MCP-compatible client (Claude Code, Cursor, or any MCP SDK client that supports the Streamable HTTP transport) at this endpoint and pass your API key as a bearer token. Send an `initialize` request via `POST /mcp/` to start a session; the server returns a session ID in the `Mcp-Session-Id` response header. Include that header on all subsequent requests.
+        Point any MCP-compatible client (Claude Code, Cursor, or any MCP SDK client that supports the Streamable HTTP transport) at this endpoint and pass your API key as a bearer token.
         
-        Include the `MCP-Protocol-Version` header on all requests after initialization, set to the protocol version negotiated during the `initialize` exchange (e.g. `2025-06-18`). Requests with an unrecognized version value are rejected with `400 Bad Request`.
+        ## Protocol revisions
+        
+        The endpoint serves the `2026-07-28` revision and, alongside it, the legacy revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
+        
+        **`2026-07-28` (recommended).** Every request stands alone: there is no `initialize` handshake, and each request carries its own protocol version and client identity in `params._meta`:
+        
+        ```json
+        {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientInfo": { "name": "my-client", "version": "1.0.0" },
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+        ```
+        
+        Requests must also carry the standard headers — `MCP-Protocol-Version`, `Mcp-Method`, and (where the body names one) `Mcp-Name` — and each must agree with the body; a disagreement is answered with `400 Bad Request` and JSON-RPC error `-32020`. A protocol version the server does not serve is answered with `-32022`, and a malformed `_meta` envelope with `-32602`.
+        
+        Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
+        
+        **Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before. Serving is stateless, so no session ID is returned and none is expected on later requests. The `GET` stream and `DELETE` session-termination operations of those revisions are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
+        
+        Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
         
         ## Available tools
         
@@ -1439,15 +1414,21 @@ paths:
         |---|---|
         | `obsidian://local-rest-api/openapi.yaml` | Full OpenAPI specification for this REST API |
       parameters:
-        - description: "Session ID returned by the server on initialization. Omit for the initial `initialize` request; required for all subsequent requests."
+        - description: "Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta[\"io.modelcontextprotocol/protocolVersion\"]`; on the legacy revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400."
           in: "header"
-          name: "Mcp-Session-Id"
+          name: "MCP-Protocol-Version"
           required: false
           schema:
             type: "string"
-        - description: "MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Required on all requests after initialization. Unrecognised values are rejected with 400."
+        - description: "The JSON-RPC method named in the request body. Required on `2026-07-28` requests; a value that disagrees with the body is rejected with 400 and JSON-RPC error `-32020`."
           in: "header"
-          name: "MCP-Protocol-Version"
+          name: "Mcp-Method"
+          required: false
+          schema:
+            type: "string"
+        - description: "The primary subject named in the request body — `params.name` for `tools/call` and `prompts/get`, `params.uri` for `resources/read`. Required on `2026-07-28` requests that carry one; a value that disagrees with the body is rejected with 400 and JSON-RPC error `-32020`."
+          in: "header"
+          name: "Mcp-Name"
           required: false
           schema:
             type: "string"
@@ -1481,13 +1462,32 @@ paths:
                     arguments:
                       path: "path/to/note.md"
                     name: "vault_read"
-              list_tools:
-                summary: "List all available MCP tools"
+              discover:
+                summary: "Discover the supported protocol revisions and capabilities (2026-07-28)"
                 value:
                   id: 1
                   jsonrpc: "2.0"
+                  method: "server/discover"
+                  params:
+                    _meta:
+                      io.modelcontextprotocol/clientCapabilities: {}
+                      io.modelcontextprotocol/clientInfo:
+                        name: "my-client"
+                        version: "1.0.0"
+                      io.modelcontextprotocol/protocolVersion: "2026-07-28"
+              list_tools:
+                summary: "List all available MCP tools (2026-07-28)"
+                value:
+                  id: 2
+                  jsonrpc: "2.0"
                   method: "tools/list"
-                  params: {}
+                  params:
+                    _meta:
+                      io.modelcontextprotocol/clientCapabilities: {}
+                      io.modelcontextprotocol/clientInfo:
+                        name: "my-client"
+                        version: "1.0.0"
+                      io.modelcontextprotocol/protocolVersion: "2026-07-28"
               read_openapi_resource:
                 summary: "Read the OpenAPI spec resource (resources/read)"
                 value:
@@ -1512,6 +1512,7 @@ paths:
                 method:
                   description: "MCP method to invoke."
                   enum:
+                    - "server/discover"
                     - "initialize"
                     - "tools/list"
                     - "tools/call"
@@ -1531,30 +1532,25 @@ paths:
         required: true
       responses:
         "200":
-          description: "Message handled. Response body contains the JSON-RPC result, or may be empty for notifications. On session initialization the `Mcp-Session-Id` response header contains the new session ID."
-          headers:
-            Mcp-Session-Id:
-              description: "Session ID assigned by the server. Present only on the `initialize` response."
-              schema:
-                type: "string"
+          description: "Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. No session ID is issued — every request is served on its own."
         "400":
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-          description: "Unsupported MCP-Protocol-Version."
+          description: "Unsupported `MCP-Protocol-Version`, or — on the `2026-07-28` revision — a JSON-RPC error response carrying `-32020` (headers disagree with the body), `-32022` (unsupported protocol version), or `-32602` (malformed `_meta` envelope)."
         "401":
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
           description: "API key required."
-        "404":
+        "405":
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-          description: "Session not found."
+          description: "Method not allowed. The `2026-07-28` revision removed the GET stream endpoint and session termination, so only POST is served."
       summary: |
         Send a JSON-RPC 2.0 message to the MCP server.
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1359,6 +1359,51 @@ paths:
       tags:
         - "Commands"
   /mcp/:
+    get:
+      description: |
+        Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the legacy protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.
+      parameters:
+        - description: "Session ID returned by the server on initialization."
+          in: "header"
+          name: "Mcp-Session-Id"
+          required: true
+          schema:
+            type: "string"
+        - description: "MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Unrecognised values are rejected with 400."
+          in: "header"
+          name: "MCP-Protocol-Version"
+          required: false
+          schema:
+            type: "string"
+      responses:
+        "200":
+          content:
+            text/event-stream:
+              schema:
+                type: "string"
+          description: "SSE stream opened. The server pushes JSON-RPC messages as server-sent events."
+        "400":
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+          description: "Unsupported MCP-Protocol-Version."
+        "401":
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+          description: "API key required."
+        "404":
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+          description: "Session not found."
+      summary: |
+        Open a server-sent events stream for an existing legacy MCP session.
+      tags:
+        - "MCP"
     post:
       description: |
         Interact with this plugin's MCP server using the [Streamable HTTP transport](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http).
@@ -1383,7 +1428,9 @@ paths:
         
         Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
         
-        **Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before. Serving is stateless, so no session ID is returned and none is expected on later requests. The `GET` stream and `DELETE` session-termination operations of those revisions are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
+        **Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before — including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
+        
+        Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live legacy session is told over its notification stream. Modern clients get the same news from a `subscriptions/listen` stream instead.
         
         Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
         
@@ -1414,6 +1461,12 @@ paths:
         |---|---|
         | `obsidian://local-rest-api/openapi.yaml` | Full OpenAPI specification for this REST API |
       parameters:
+        - description: "Session ID returned by the server on initialization. A session operation of the legacy protocol revisions: omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there."
+          in: "header"
+          name: "Mcp-Session-Id"
+          required: false
+          schema:
+            type: "string"
         - description: "Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta[\"io.modelcontextprotocol/protocolVersion\"]`; on the legacy revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400."
           in: "header"
           name: "MCP-Protocol-Version"
@@ -1532,7 +1585,12 @@ paths:
         required: true
       responses:
         "200":
-          description: "Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. No session ID is issued — every request is served on its own."
+          description: "Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a legacy `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one."
+          headers:
+            Mcp-Session-Id:
+              description: "Session ID assigned by the server. Present only on a legacy `initialize` response."
+              schema:
+                type: "string"
         "400":
           content:
             application/json:
@@ -1545,12 +1603,12 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
           description: "API key required."
-        "405":
+        "404":
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-          description: "Method not allowed. The `2026-07-28` revision removed the GET stream endpoint and session termination, so only POST is served."
+          description: "Session not found. The `Mcp-Session-Id` header names a legacy session that has ended; hand-shake again with `initialize`."
       summary: |
         Send a JSON-RPC 2.0 message to the MCP server.
       tags:

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -4,7 +4,7 @@ Point any MCP-compatible client (Claude Code, Cursor, or any MCP SDK client that
 
 ## Protocol revisions
 
-The endpoint serves the `2026-07-28` revision and, alongside it, the legacy revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
+The endpoint serves the `2026-07-28` revision and, alongside it, the sessionful revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
 
 **`2026-07-28` (recommended).** Every request stands alone: there is no `initialize` handshake, and each request carries its own protocol version and client identity in `params._meta`:
 
@@ -20,9 +20,9 @@ Requests must also carry the standard headers — `MCP-Protocol-Version`, `Mcp-M
 
 Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
 
-**Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before — including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
+**Sessionful revisions (`2024-10-07` through `2025-11-25`).** Clients that open with an `initialize` request are served the revision they negotiate, including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
 
-Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live legacy session is told over its notification stream. Modern clients get the same news from a `subscriptions/listen` stream instead.
+Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live session is told over its notification stream. `2026-07-28` clients get the same news from a `subscriptions/listen` stream instead.
 
 Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
 

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -20,7 +20,9 @@ Requests must also carry the standard headers — `MCP-Protocol-Version`, `Mcp-M
 
 Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
 
-**Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before. Serving is stateless, so no session ID is returned and none is expected on later requests. The `GET` stream and `DELETE` session-termination operations of those revisions are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
+**Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before — including sessions. The server returns a session ID in the `Mcp-Session-Id` response header; include it on every later request, use `GET /mcp/` with it to open the server-to-client notification stream, and `DELETE /mcp/` with it to end the session. A request naming a session that no longer exists is answered `404 Not Found`, which means the client should hand-shake again.
+
+Sessions exist only on this path. They are what makes the `tools.listChanged` / `resources.listChanged` capabilities the handshake advertises true: when another plugin registers or removes an MCP tool, every live legacy session is told over its notification stream. Modern clients get the same news from a `subscriptions/listen` stream instead.
 
 Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
 

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -1,8 +1,28 @@
 Interact with this plugin's MCP server using the [Streamable HTTP transport](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http).
 
-Point any MCP-compatible client (Claude Code, Cursor, or any MCP SDK client that supports the Streamable HTTP transport) at this endpoint and pass your API key as a bearer token. Send an `initialize` request via `POST /mcp/` to start a session; the server returns a session ID in the `Mcp-Session-Id` response header. Include that header on all subsequent requests.
+Point any MCP-compatible client (Claude Code, Cursor, or any MCP SDK client that supports the Streamable HTTP transport) at this endpoint and pass your API key as a bearer token.
 
-Include the `MCP-Protocol-Version` header on all requests after initialization, set to the protocol version negotiated during the `initialize` exchange (e.g. `2025-06-18`). Requests with an unrecognized version value are rejected with `400 Bad Request`.
+## Protocol revisions
+
+The endpoint serves the `2026-07-28` revision and, alongside it, the legacy revisions from `2024-10-07` through `2025-11-25`. Which one a request gets is decided per request, from the request itself — there are no sessions and the `Mcp-Session-Id` header is neither issued nor read.
+
+**`2026-07-28` (recommended).** Every request stands alone: there is no `initialize` handshake, and each request carries its own protocol version and client identity in `params._meta`:
+
+```json
+{
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientInfo": { "name": "my-client", "version": "1.0.0" },
+  "io.modelcontextprotocol/clientCapabilities": {}
+}
+```
+
+Requests must also carry the standard headers — `MCP-Protocol-Version`, `Mcp-Method`, and (where the body names one) `Mcp-Name` — and each must agree with the body; a disagreement is answered with `400 Bad Request` and JSON-RPC error `-32020`. A protocol version the server does not serve is answered with `-32022`, and a malformed `_meta` envelope with `-32602`.
+
+Call `server/discover` to learn the supported revisions, capabilities, and server identity in one request. Results carry `resultType`, and the cacheable ones (`server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`) also carry the `ttlMs` and `cacheScope` freshness hints.
+
+**Legacy revisions.** Clients that open with an `initialize` request are served the revision they negotiate, exactly as before. Serving is stateless, so no session ID is returned and none is expected on later requests. The `GET` stream and `DELETE` session-termination operations of those revisions are answered with `405 Method Not Allowed`; MCP SDK clients treat that as "no server-initiated stream" and carry on.
+
+Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `400 Bad Request`.
 
 ## Available tools
 

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -804,11 +804,87 @@ std.manifestYamlDoc(
         },
       },
       '/mcp/': {
+        get: {
+          tags: ['MCP'],
+          summary: 'Open a server-sent events stream for an existing legacy MCP session.\n',
+          description: 'Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the legacy protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.\n',
+          parameters: [
+            {
+              name: 'Mcp-Session-Id',
+              'in': 'header',
+              description: 'Session ID returned by the server on initialization.',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'MCP-Protocol-Version',
+              'in': 'header',
+              description: 'MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Unrecognised values are rejected with 400.',
+              required: false,
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+          responses: {
+            '200': {
+              description: 'SSE stream opened. The server pushes JSON-RPC messages as server-sent events.',
+              content: {
+                'text/event-stream': {
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+            '400': {
+              description: 'Unsupported MCP-Protocol-Version.',
+              content: {
+                'application/json': {
+                  schema: {
+                    '$ref': '#/components/schemas/Error',
+                  },
+                },
+              },
+            },
+            '404': {
+              description: 'Session not found.',
+              content: {
+                'application/json': {
+                  schema: {
+                    '$ref': '#/components/schemas/Error',
+                  },
+                },
+              },
+            },
+            '401': {
+              description: 'API key required.',
+              content: {
+                'application/json': {
+                  schema: {
+                    '$ref': '#/components/schemas/Error',
+                  },
+                },
+              },
+            },
+          },
+        },
         post: {
           tags: ['MCP'],
           summary: 'Send a JSON-RPC 2.0 message to the MCP server.\n',
           description: importstr 'lib/descriptions/mcp.md',
           parameters: [
+            {
+              name: 'Mcp-Session-Id',
+              'in': 'header',
+              description: 'Session ID returned by the server on initialization. A session operation of the legacy protocol revisions: omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there.',
+              required: false,
+              schema: {
+                type: 'string',
+              },
+            },
             {
               name: 'MCP-Protocol-Version',
               'in': 'header',
@@ -956,7 +1032,15 @@ std.manifestYamlDoc(
           },
           responses: {
             '200': {
-              description: 'Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. No session ID is issued — every request is served on its own.',
+              description: 'Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a legacy `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one.',
+              headers: {
+                'Mcp-Session-Id': {
+                  description: 'Session ID assigned by the server. Present only on a legacy `initialize` response.',
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
             },
             '400': {
               description: 'Unsupported `MCP-Protocol-Version`, or — on the `2026-07-28` revision — a JSON-RPC error response carrying `-32020` (headers disagree with the body), `-32022` (unsupported protocol version), or `-32602` (malformed `_meta` envelope).',
@@ -978,8 +1062,8 @@ std.manifestYamlDoc(
                 },
               },
             },
-            '405': {
-              description: 'Method not allowed. The `2026-07-28` revision removed the GET stream endpoint and session termination, so only POST is served.',
+            '404': {
+              description: 'Session not found. The `Mcp-Session-Id` header names a legacy session that has ended; hand-shake again with `initialize`.',
               content: {
                 'application/json': {
                   schema: {

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -804,91 +804,33 @@ std.manifestYamlDoc(
         },
       },
       '/mcp/': {
-        get: {
-          tags: ['MCP'],
-          summary: 'Open a server-sent events stream for an existing MCP session.\n',
-          description: 'Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response.\n',
-          parameters: [
-            {
-              name: 'Mcp-Session-Id',
-              'in': 'header',
-              description: 'Session ID returned by the server on initialization.',
-              required: true,
-              schema: {
-                type: 'string',
-              },
-            },
-            {
-              name: 'MCP-Protocol-Version',
-              'in': 'header',
-              description: 'MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Required on all requests after initialization. Unrecognised values are rejected with 400.',
-              required: false,
-              schema: {
-                type: 'string',
-              },
-            },
-          ],
-          responses: {
-            '200': {
-              description: 'SSE stream opened. The server pushes JSON-RPC messages as server-sent events.',
-              content: {
-                'text/event-stream': {
-                  schema: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-            '400': {
-              description: 'Unsupported MCP-Protocol-Version.',
-              content: {
-                'application/json': {
-                  schema: {
-                    '$ref': '#/components/schemas/Error',
-                  },
-                },
-              },
-            },
-            '404': {
-              description: 'Session not found.',
-              content: {
-                'application/json': {
-                  schema: {
-                    '$ref': '#/components/schemas/Error',
-                  },
-                },
-              },
-            },
-            '401': {
-              description: 'API key required.',
-              content: {
-                'application/json': {
-                  schema: {
-                    '$ref': '#/components/schemas/Error',
-                  },
-                },
-              },
-            },
-          },
-        },
         post: {
           tags: ['MCP'],
           summary: 'Send a JSON-RPC 2.0 message to the MCP server.\n',
           description: importstr 'lib/descriptions/mcp.md',
           parameters: [
             {
-              name: 'Mcp-Session-Id',
+              name: 'MCP-Protocol-Version',
               'in': 'header',
-              description: 'Session ID returned by the server on initialization. Omit for the initial `initialize` request; required for all subsequent requests.',
+              description: 'Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta["io.modelcontextprotocol/protocolVersion"]`; on the legacy revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400.',
               required: false,
               schema: {
                 type: 'string',
               },
             },
             {
-              name: 'MCP-Protocol-Version',
+              name: 'Mcp-Method',
               'in': 'header',
-              description: 'MCP protocol version negotiated during initialization (e.g. `2025-06-18`). Required on all requests after initialization. Unrecognised values are rejected with 400.',
+              description: 'The JSON-RPC method named in the request body. Required on `2026-07-28` requests; a value that disagrees with the body is rejected with 400 and JSON-RPC error `-32020`.',
+              required: false,
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'Mcp-Name',
+              'in': 'header',
+              description: 'The primary subject named in the request body — `params.name` for `tools/call` and `prompts/get`, `params.uri` for `resources/read`. Required on `2026-07-28` requests that carry one; a value that disagrees with the body is rejected with 400 and JSON-RPC error `-32020`.',
               required: false,
               schema: {
                 type: 'string',
@@ -917,6 +859,7 @@ std.manifestYamlDoc(
                       type: 'string',
                       description: 'MCP method to invoke.',
                       enum: [
+                        'server/discover',
                         'initialize',
                         'tools/list',
                         'tools/call',
@@ -934,13 +877,34 @@ std.manifestYamlDoc(
                   },
                 },
                 examples: {
-                  list_tools: {
-                    summary: 'List all available MCP tools',
+                  discover: {
+                    summary: 'Discover the supported protocol revisions and capabilities (2026-07-28)',
                     value: {
                       jsonrpc: '2.0',
                       id: 1,
+                      method: 'server/discover',
+                      params: {
+                        _meta: {
+                          'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+                          'io.modelcontextprotocol/clientInfo': { name: 'my-client', version: '1.0.0' },
+                          'io.modelcontextprotocol/clientCapabilities': {},
+                        },
+                      },
+                    },
+                  },
+                  list_tools: {
+                    summary: 'List all available MCP tools (2026-07-28)',
+                    value: {
+                      jsonrpc: '2.0',
+                      id: 2,
                       method: 'tools/list',
-                      params: {},
+                      params: {
+                        _meta: {
+                          'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+                          'io.modelcontextprotocol/clientInfo': { name: 'my-client', version: '1.0.0' },
+                          'io.modelcontextprotocol/clientCapabilities': {},
+                        },
+                      },
                     },
                   },
                   call_vault_read: {
@@ -992,28 +956,10 @@ std.manifestYamlDoc(
           },
           responses: {
             '200': {
-              description: 'Message handled. Response body contains the JSON-RPC result, or may be empty for notifications. On session initialization the `Mcp-Session-Id` response header contains the new session ID.',
-              headers: {
-                'Mcp-Session-Id': {
-                  description: 'Session ID assigned by the server. Present only on the `initialize` response.',
-                  schema: {
-                    type: 'string',
-                  },
-                },
-              },
+              description: 'Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. No session ID is issued — every request is served on its own.',
             },
             '400': {
-              description: 'Unsupported MCP-Protocol-Version.',
-              content: {
-                'application/json': {
-                  schema: {
-                    '$ref': '#/components/schemas/Error',
-                  },
-                },
-              },
-            },
-            '404': {
-              description: 'Session not found.',
+              description: 'Unsupported `MCP-Protocol-Version`, or — on the `2026-07-28` revision — a JSON-RPC error response carrying `-32020` (headers disagree with the body), `-32022` (unsupported protocol version), or `-32602` (malformed `_meta` envelope).',
               content: {
                 'application/json': {
                   schema: {
@@ -1024,6 +970,16 @@ std.manifestYamlDoc(
             },
             '401': {
               description: 'API key required.',
+              content: {
+                'application/json': {
+                  schema: {
+                    '$ref': '#/components/schemas/Error',
+                  },
+                },
+              },
+            },
+            '405': {
+              description: 'Method not allowed. The `2026-07-28` revision removed the GET stream endpoint and session termination, so only POST is served.',
               content: {
                 'application/json': {
                   schema: {

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -806,8 +806,8 @@ std.manifestYamlDoc(
       '/mcp/': {
         get: {
           tags: ['MCP'],
-          summary: 'Open a server-sent events stream for an existing legacy MCP session.\n',
-          description: 'Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the legacy protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.\n',
+          summary: 'Open a server-sent events stream for an existing sessionful MCP session.\n',
+          description: 'Opens a long-lived SSE stream so the server can push messages to the client for an existing session. Requires the session ID returned by the `initialize` response. This is a session operation of the sessionful protocol revisions (`2024-10-07` through `2025-11-25`); the `2026-07-28` revision removed it, and clients on that revision open a `subscriptions/listen` stream over POST instead.\n',
           parameters: [
             {
               name: 'Mcp-Session-Id',
@@ -879,7 +879,7 @@ std.manifestYamlDoc(
             {
               name: 'Mcp-Session-Id',
               'in': 'header',
-              description: 'Session ID returned by the server on initialization. A session operation of the legacy protocol revisions: omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there.',
+              description: 'Session ID returned by the server on initialization. A session operation of the sessionful protocol revisions (`2024-10-07` through `2025-11-25`): omit it for the initial `initialize` request, send it on every later request of that session, and expect 404 if the session has ended. The `2026-07-28` revision has no sessions — the header is neither issued nor read there.',
               required: false,
               schema: {
                 type: 'string',
@@ -888,7 +888,7 @@ std.manifestYamlDoc(
             {
               name: 'MCP-Protocol-Version',
               'in': 'header',
-              description: 'Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta["io.modelcontextprotocol/protocolVersion"]`; on the legacy revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400.',
+              description: 'Protocol revision this request speaks. Required on every request on the `2026-07-28` revision, where it must match `params._meta["io.modelcontextprotocol/protocolVersion"]`; on the sessionful revisions it carries the version negotiated during `initialize` (e.g. `2025-06-18`). Unrecognised values are rejected with 400.',
               required: false,
               schema: {
                 type: 'string',
@@ -1032,10 +1032,10 @@ std.manifestYamlDoc(
           },
           responses: {
             '200': {
-              description: 'Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a legacy `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one.',
+              description: 'Message handled. The body is either a single JSON-RPC response (`application/json`) or a server-sent event stream carrying request-scoped notifications followed by the response (`text/event-stream`); notifications are answered with `202 Accepted` and no body. On a sessionful-revision `initialize` the `Mcp-Session-Id` response header carries the new session ID; `2026-07-28` requests are served without one.',
               headers: {
                 'Mcp-Session-Id': {
-                  description: 'Session ID assigned by the server. Present only on a legacy `initialize` response.',
+                  description: 'Session ID assigned by the server. Present only on a sessionful-revision `initialize` response.',
                   schema: {
                     type: 'string',
                   },
@@ -1063,7 +1063,7 @@ std.manifestYamlDoc(
               },
             },
             '404': {
-              description: 'Session not found. The `Mcp-Session-Id` header names a legacy session that has ended; hand-shake again with `initialize`.',
+              description: 'Session not found. The `Mcp-Session-Id` header names a session that has ended; hand-shake again with `initialize`.',
               content: {
                 'application/json': {
                   schema: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/sdk": "1.30.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/glob-to-regexp": "^0.4.1",
@@ -514,6 +516,278 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
       "cpu": [
@@ -524,6 +798,159 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1172,6 +1599,64 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "dev": true,
@@ -1544,6 +2029,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@noble/hashes": {
@@ -4521,6 +5030,21 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/sdk": "1.30.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/glob-to-regexp": "^0.4.1",

--- a/publicApi.d.ts
+++ b/publicApi.d.ts
@@ -34,7 +34,7 @@ export declare const LOCAL_REST_API_PLUGIN_ID = "obsidian-local-rest-api";
 /**
  * Behavior hints attached to a registered MCP tool.
  *
- * Structurally identical to `ToolAnnotations` from `@modelcontextprotocol/sdk`, but
+ * Structurally identical to `ToolAnnotations` from `@modelcontextprotocol/server`, but
  * declared here so that consuming this package's types does not require the SDK to be
  * installed. The host passes whatever it receives straight through to the SDK.
  */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { z } from "zod";
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/server";
 import { BUILT_IN_ROUTES } from "./constants";
 import { McpHandler } from "./mcpHandler";
 import type { LocalRestApiPublicApi } from "./publicApi";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,15 @@ export const CERT_NAME = "obsidian-local-rest-api.crt";
 
 export const BUILT_IN_ROUTES = ["/", "/openapi.yaml", `/${CERT_NAME}`];
 
+/**
+ * The MCP protocol revision the `/mcp/` endpoint's modern path speaks.
+ *
+ * The SDK's `SUPPORTED_PROTOCOL_VERSIONS` deliberately lists only the 2025-era revisions
+ * served by the legacy path, and exports no constant for the modern one, so it is named
+ * here — the `MCP-Protocol-Version` header filter has to accept both eras.
+ */
+export const MCP_MODERN_PROTOCOL_VERSION = "2026-07-28";
+
 export const DEFAULT_SETTINGS: LocalRestApiSettings = {
   port: 27124,
   insecurePort: 27123,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,13 +5,13 @@ export const CERT_NAME = "obsidian-local-rest-api.crt";
 export const BUILT_IN_ROUTES = ["/", "/openapi.yaml", `/${CERT_NAME}`];
 
 /**
- * The MCP protocol revision the `/mcp/` endpoint's modern path speaks.
+ * The MCP protocol revision served by the `/mcp/` endpoint's sessionless leg.
  *
- * The SDK's `SUPPORTED_PROTOCOL_VERSIONS` deliberately lists only the 2025-era revisions
- * served by the legacy path, and exports no constant for the modern one, so it is named
- * here — the `MCP-Protocol-Version` header filter has to accept both eras.
+ * The SDK's `SUPPORTED_PROTOCOL_VERSIONS` lists only the sessionful revisions
+ * (2024-10-07 through 2025-11-25) and exports no constant for this one, so it is named
+ * here: the `MCP-Protocol-Version` header filter accepts both sets.
  */
-export const MCP_MODERN_PROTOCOL_VERSION = "2026-07-28";
+export const MCP_SESSIONLESS_PROTOCOL_VERSION = "2026-07-28";
 
 export const DEFAULT_SETTINGS: LocalRestApiSettings = {
   port: 27124,

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -27,9 +27,9 @@ import {
   TERM_SUB,
 } from "./fixtures";
 
-// Legacy-era coverage: this suite drives the v1 MCP SDK client, which opens with the
-// `initialize` handshake and therefore exercises the endpoint's legacy path end to end.
-// The 2026-07-28 path is covered by mcpModern.test.ts.
+// Sessionful-leg coverage: this suite drives the v1 MCP SDK client, which opens with the
+// `initialize` handshake and therefore exercises the endpoint's sessionful leg end to end.
+// The sessionless (2026-07-28) leg is covered by mcpSessionless.test.ts.
 
 // A separate temp path so vault_write / vault_delete tests don't touch the shared fixture.
 const TEMP_PATH = `${TEST_DIR}/mcp-temp.md`;
@@ -87,11 +87,11 @@ afterAll(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Session lifecycle — the 2025-era revisions are sessionful, and the capabilities the
+// Session lifecycle — revisions 2024-10-07 through 2025-11-25 are sessionful, and the capabilities the
 // handshake advertises (tools.listChanged) only hold while a session is live.
 // ---------------------------------------------------------------------------
 
-describe("MCP legacy session lifecycle", () => {
+describe("MCP sessionful lifecycle", () => {
   async function initialize(): Promise<{ sessionId: string | null; result: any }> {
     const res = await authedFetch("/mcp/", {
       method: "POST",
@@ -106,7 +106,7 @@ describe("MCP legacy session lifecycle", () => {
         params: {
           protocolVersion: "2025-06-18",
           capabilities: {},
-          clientInfo: { name: "integration-test-legacy", version: "1.0.0" },
+          clientInfo: { name: "integration-test-sessionful", version: "1.0.0" },
         },
       }),
     });

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -26,6 +26,10 @@ import {
   TERM_SUB,
 } from "./fixtures";
 
+// Legacy-era coverage: this suite drives the v1 MCP SDK client, which opens with the
+// `initialize` handshake and therefore exercises the endpoint's legacy path end to end.
+// The 2026-07-28 path is covered by mcpModern.test.ts.
+
 // A separate temp path so vault_write / vault_delete tests don't touch the shared fixture.
 const TEMP_PATH = `${TEST_DIR}/mcp-temp.md`;
 

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import {
   API_KEY,
   BASE_URL,
+  authedFetch,
   ensureServerReachable,
   resetFixture,
   deleteFixture,
@@ -83,6 +84,71 @@ afterAll(async () => {
   await deleteFixture(TEST_PATH);
   // Best-effort cleanup of the temp path used by write/delete tests.
   await deleteFixture(TEMP_PATH).catch((_e: unknown): void => {});
+});
+
+// ---------------------------------------------------------------------------
+// Session lifecycle — the 2025-era revisions are sessionful, and the capabilities the
+// handshake advertises (tools.listChanged) only hold while a session is live.
+// ---------------------------------------------------------------------------
+
+describe("MCP legacy session lifecycle", () => {
+  async function initialize(): Promise<{ sessionId: string | null; result: any }> {
+    const res = await authedFetch("/mcp/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "integration-test-legacy", version: "1.0.0" },
+        },
+      }),
+    });
+    const text = await res.text();
+    const line = text.split("\n").find((l) => l.startsWith("data: "));
+    if (!line) throw new Error(`No SSE data frame in initialize response: ${text}`);
+    return {
+      sessionId: res.headers.get("mcp-session-id"),
+      result: JSON.parse(line.slice("data: ".length)).result,
+    };
+  }
+
+  test("initialize hands back a session id and listChanged capabilities", async () => {
+    const { sessionId, result } = await initialize();
+    expect(typeof sessionId).toBe("string");
+    expect(result.protocolVersion).toBe("2025-06-18");
+    expect(result.capabilities.tools.listChanged).toBe(true);
+    expect(result.capabilities.resources.listChanged).toBe(true);
+  });
+
+  test("an unknown session id is rejected with 404", async () => {
+    const res = await authedFetch("/mcp/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2025-06-18",
+        "Mcp-Session-Id": "a-session-that-never-existed",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("DELETE terminates a session", async () => {
+    const { sessionId } = await initialize();
+    const res = await authedFetch("/mcp/", {
+      method: "DELETE",
+      headers: { "Mcp-Session-Id": sessionId ?? "" },
+    });
+    expect(res.status).toBe(200);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/integration/mcpModern.test.ts
+++ b/src/integration/mcpModern.test.ts
@@ -230,17 +230,25 @@ describe("MCP 2026-07-28 header and version validation", () => {
   });
 });
 
-describe("MCP 2026-07-28 removed session operations", () => {
-  test("GET no longer opens a standalone stream", async () => {
-    const res = await authedFetch(MCP_PATH, {
-      method: "GET",
-      headers: { Accept: "text/event-stream" },
-    });
-    expect(res.status).toBe(405);
+describe("MCP 2026-07-28 session handling", () => {
+  test("the modern leg never issues a session id", async () => {
+    for (const method of ["server/discover", "tools/list", "resources/list"]) {
+      const { sessionId } = await call(method);
+      expect(sessionId).toBeNull();
+    }
   });
 
-  test("DELETE no longer terminates a session", async () => {
-    const res = await authedFetch(MCP_PATH, { method: "DELETE" });
-    expect(res.status).toBe(405);
+  test("a body-less session operation with an unknown version keeps the plain rejection", async () => {
+    // The endpoint's version filter still guards the 2025-era session operations, which
+    // carry no body for the SDK to classify.
+    for (const method of ["GET", "DELETE"]) {
+      const res = await authedFetch(MCP_PATH, {
+        method,
+        headers: { "MCP-Protocol-Version": "9999-01-01" },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: unknown };
+      expect(typeof body.error).toBe("string");
+    }
   });
 });

--- a/src/integration/mcpModern.test.ts
+++ b/src/integration/mcpModern.test.ts
@@ -1,0 +1,246 @@
+import {
+  authedFetch,
+  unauthFetch,
+  ensureServerReachable,
+  resetFixture,
+  deleteFixture,
+} from "./client";
+import { TEST_DIR, TEST_PATH, FIXTURE_DOCUMENT } from "./fixtures";
+
+// Integration coverage for the 2026-07-28 protocol revision.
+//
+// The requests are hand-built rather than driven through an SDK client on purpose: this
+// revision's contract is a set of wire-level requirements — the per-request `_meta`
+// envelope, the standard `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers, and
+// the `resultType` / `ttlMs` / `cacheScope` fields on results — and asserting them
+// directly is the only way to prove a real client would see them. The 2025-era client
+// path is covered by mcp.test.ts, which drives the SDK's `initialize` handshake.
+
+const MODERN_VERSION = "2026-07-28";
+const MCP_PATH = "/mcp/";
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: number;
+  result?: Record<string, any>;
+  error?: { code: number; message: string; data?: Record<string, any> };
+}
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": { name: "integration-test", version: "1.0.0" },
+    "io.modelcontextprotocol/clientCapabilities": {},
+    ...overrides,
+  };
+}
+
+interface ModernCallOptions {
+  params?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  envelopeOverrides?: Record<string, unknown>;
+}
+
+let nextId = 1;
+
+async function call(
+  method: string,
+  { params = {}, headers = {}, envelopeOverrides = {} }: ModernCallOptions = {},
+): Promise<{ status: number; sessionId: string | null; body: JsonRpcResponse }> {
+  const id = nextId++;
+  const res = await authedFetch(MCP_PATH, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "MCP-Protocol-Version": MODERN_VERSION,
+      "Mcp-Method": method,
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params: { ...params, _meta: envelope(envelopeOverrides) },
+    }),
+  });
+  return {
+    status: res.status,
+    sessionId: res.headers.get("mcp-session-id"),
+    body: (await res.json()) as JsonRpcResponse,
+  };
+}
+
+beforeAll(async () => {
+  await ensureServerReachable();
+  await resetFixture(FIXTURE_DOCUMENT, TEST_PATH);
+});
+
+afterAll(async () => {
+  await deleteFixture(TEST_PATH);
+});
+
+describe("MCP 2026-07-28 discovery", () => {
+  test("server/discover reports the modern revision, capabilities, and identity", async () => {
+    const { status, body } = await call("server/discover");
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.supportedVersions).toContain(MODERN_VERSION);
+    expect(body.result?.capabilities.tools).toBeDefined();
+    expect(body.result?.capabilities.resources).toBeDefined();
+    expect(body.result?._meta["io.modelcontextprotocol/serverInfo"].name).toBe(
+      "obsidian-local-rest-api",
+    );
+  });
+
+  test("every result carries resultType 'complete'", async () => {
+    const discover = await call("server/discover");
+    const tools = await call("tools/list");
+    expect(discover.body.result?.resultType).toBe("complete");
+    expect(tools.body.result?.resultType).toBe("complete");
+  });
+
+  test("cacheable results carry ttlMs and a private cacheScope", async () => {
+    for (const method of ["server/discover", "tools/list", "resources/list"]) {
+      const { body } = await call(method);
+      expect(typeof body.result?.ttlMs).toBe("number");
+      expect(body.result?.cacheScope).toBe("private");
+    }
+  });
+});
+
+describe("MCP 2026-07-28 stateless requests", () => {
+  test("tools/call succeeds with no prior initialize and mints no session id", async () => {
+    const { status, sessionId, body } = await call("tools/call", {
+      params: { name: "vault_list", arguments: { path: TEST_DIR } },
+      headers: { "Mcp-Name": "vault_list" },
+    });
+
+    expect(status).toBe(200);
+    expect(sessionId).toBeNull();
+    expect(body.error).toBeUndefined();
+    const listed = JSON.parse(body.result?.content[0].text as string) as { files: string[] };
+    expect(listed.files.some((f) => f.includes("fixture"))).toBe(true);
+  });
+
+  test("consecutive calls are independent — neither sends nor needs a session id", async () => {
+    const first = await call("tools/call", {
+      params: { name: "vault_read", arguments: { path: TEST_PATH } },
+      headers: { "Mcp-Name": "vault_read" },
+    });
+    const second = await call("tools/call", {
+      params: { name: "vault_read", arguments: { path: TEST_PATH } },
+      headers: { "Mcp-Name": "vault_read" },
+    });
+
+    expect(first.sessionId).toBeNull();
+    expect(second.sessionId).toBeNull();
+    expect(JSON.parse(first.body.result?.content[0].text as string).path).toBe(TEST_PATH);
+    expect(JSON.parse(second.body.result?.content[0].text as string).path).toBe(TEST_PATH);
+  });
+
+  test("a stale Mcp-Session-Id header is ignored rather than rejected", async () => {
+    const { status, body } = await call("tools/list", {
+      headers: { "Mcp-Session-Id": "a-session-that-never-existed" },
+    });
+    expect(status).toBe(200);
+    expect(body.result?.tools.length).toBeGreaterThan(0);
+  });
+
+  test("resources/read serves the OpenAPI spec", async () => {
+    const uri = "obsidian://local-rest-api/openapi.yaml";
+    const { body } = await call("resources/read", {
+      params: { uri },
+      headers: { "Mcp-Name": uri },
+    });
+    expect(body.result?.contents[0].text).toContain("openapi:");
+  });
+});
+
+describe("MCP 2026-07-28 header and version validation", () => {
+  test("an Mcp-Method header that disagrees with the body is rejected with -32020", async () => {
+    const { status, body } = await call("tools/list", {
+      headers: { "Mcp-Method": "tools/call" },
+    });
+    expect(status).toBe(400);
+    expect(body.error?.code).toBe(-32020);
+  });
+
+  test("a missing Mcp-Name header on tools/call is rejected with -32020", async () => {
+    const { status, body } = await call("tools/call", {
+      params: { name: "vault_list", arguments: {} },
+    });
+    expect(status).toBe(400);
+    expect(body.error?.code).toBe(-32020);
+  });
+
+  test("an unsupported protocol version is rejected with -32022", async () => {
+    const res = await authedFetch(MCP_PATH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2026-07-29",
+        "Mcp-Method": "tools/list",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: nextId++,
+        method: "tools/list",
+        params: {
+          _meta: envelope({ "io.modelcontextprotocol/protocolVersion": "2026-07-29" }),
+        },
+      }),
+    });
+    const body = (await res.json()) as JsonRpcResponse;
+    expect(res.status).toBe(400);
+    expect(body.error?.code).toBe(-32022);
+    expect(body.error?.data?.supported).toContain(MODERN_VERSION);
+  });
+
+  test("a version the endpoint filter does not know is rejected before the SDK sees it", async () => {
+    const res = await authedFetch(MCP_PATH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "9999-01-01",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: nextId++, method: "tools/list", params: {} }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("a modern request without authentication is rejected", async () => {
+    const res = await unauthFetch(MCP_PATH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": MODERN_VERSION,
+        "Mcp-Method": "tools/list",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: nextId++,
+        method: "tools/list",
+        params: { _meta: envelope() },
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("MCP 2026-07-28 removed session operations", () => {
+  test("GET no longer opens a standalone stream", async () => {
+    const res = await authedFetch(MCP_PATH, {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(res.status).toBe(405);
+  });
+
+  test("DELETE no longer terminates a session", async () => {
+    const res = await authedFetch(MCP_PATH, { method: "DELETE" });
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/integration/mcpSessionless.test.ts
+++ b/src/integration/mcpSessionless.test.ts
@@ -13,8 +13,8 @@ import { TEST_DIR, TEST_PATH, FIXTURE_DOCUMENT } from "./fixtures";
 // revision's contract is a set of wire-level requirements — the per-request `_meta`
 // envelope, the standard `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers, and
 // the `resultType` / `ttlMs` / `cacheScope` fields on results — and asserting them
-// directly is the only way to prove a real client would see them. The 2025-era client
-// path is covered by mcp.test.ts, which drives the SDK's `initialize` handshake.
+// directly is the only way to prove a real client would see them. The sessionful client
+// path is covered by mcp.test.ts, which drives the v1 SDK's `initialize` handshake.
 
 const MODERN_VERSION = "2026-07-28";
 const MCP_PATH = "/mcp/";
@@ -35,7 +35,7 @@ function envelope(overrides: Record<string, unknown> = {}) {
   };
 }
 
-interface ModernCallOptions {
+interface SessionlessCallOptions {
   params?: Record<string, unknown>;
   headers?: Record<string, string>;
   envelopeOverrides?: Record<string, unknown>;
@@ -45,7 +45,7 @@ let nextId = 1;
 
 async function call(
   method: string,
-  { params = {}, headers = {}, envelopeOverrides = {} }: ModernCallOptions = {},
+  { params = {}, headers = {}, envelopeOverrides = {} }: SessionlessCallOptions = {},
 ): Promise<{ status: number; sessionId: string | null; body: JsonRpcResponse }> {
   const id = nextId++;
   const res = await authedFetch(MCP_PATH, {
@@ -81,7 +81,7 @@ afterAll(async () => {
 });
 
 describe("MCP 2026-07-28 discovery", () => {
-  test("server/discover reports the modern revision, capabilities, and identity", async () => {
+  test("server/discover reports the 2026-07-28 revision, capabilities, and identity", async () => {
     const { status, body } = await call("server/discover");
     expect(status).toBe(200);
     expect(body.error).toBeUndefined();
@@ -210,7 +210,7 @@ describe("MCP 2026-07-28 header and version validation", () => {
     expect(res.status).toBe(400);
   });
 
-  test("a modern request without authentication is rejected", async () => {
+  test("a sessionless request without authentication is rejected", async () => {
     const res = await unauthFetch(MCP_PATH, {
       method: "POST",
       headers: {
@@ -231,7 +231,7 @@ describe("MCP 2026-07-28 header and version validation", () => {
 });
 
 describe("MCP 2026-07-28 session handling", () => {
-  test("the modern leg never issues a session id", async () => {
+  test("the sessionless leg never issues a session id", async () => {
     for (const method of ["server/discover", "tools/list", "resources/list"]) {
       const { sessionId } = await call(method);
       expect(sessionId).toBeNull();
@@ -239,7 +239,7 @@ describe("MCP 2026-07-28 session handling", () => {
   });
 
   test("a body-less session operation with an unknown version keeps the plain rejection", async () => {
-    // The endpoint's version filter still guards the 2025-era session operations, which
+    // The endpoint's version filter guards the sessionful session operations, which
     // carry no body for the SDK to classify.
     for (const method of ["GET", "DELETE"]) {
       const res = await authedFetch(MCP_PATH, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,6 +248,7 @@ export default class LocalRestApi extends Plugin {
   }
 
   onunload() {
+    this.requestHandler?.mcpHandler.close();
     if (this.secureServer) {
       this.secureServer.closeAllConnections();
       this.secureServer.close();

--- a/src/mcpEndpoint.test.ts
+++ b/src/mcpEndpoint.test.ts
@@ -1,0 +1,196 @@
+import http from "http";
+import request from "supertest";
+
+import RequestHandler from "./requestHandler";
+import { LocalRestApiSettings } from "./types";
+import { App, PluginManifest } from "../mocks/obsidian";
+
+// The mounted `/mcp/` endpoint, wired through the real RequestHandler *and* the real
+// McpHandler. requestHandler.test.ts mocks McpHandler, which means it cannot show what
+// the router's middleware order does to a real request: whether an unrecognised protocol
+// version is answered by the router or reaches the SDK, and whether the modern and legacy
+// legs are picked correctly, are both decided by that order.
+
+const API_KEY = "my api key";
+const MODERN_VERSION = "2026-07-28";
+const LEGACY_VERSION = "2025-06-18";
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": { name: "endpoint-test", version: "1.0.0" },
+    "io.modelcontextprotocol/clientCapabilities": {},
+    ...overrides,
+  };
+}
+
+function modernBody(
+  id: number,
+  method: string,
+  params: Record<string, unknown> = {},
+  envelopeOverrides: Record<string, unknown> = {},
+) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: { ...params, _meta: envelope(envelopeOverrides) },
+  };
+}
+
+// Read the JSON-RPC message out of a legacy SSE response.
+function sseResult(text: string) {
+  const line = text.split("\n").find((l) => l.startsWith("data: "));
+  if (!line) throw new Error(`No SSE data frame in response: ${text}`);
+  return JSON.parse(line.slice("data: ".length));
+}
+
+describe("mounted /mcp/ endpoint", () => {
+  let handler: RequestHandler;
+  let server: http.Server;
+
+  beforeEach(() => {
+    const settings: LocalRestApiSettings = {
+      apiKey: API_KEY,
+      crypto: { cert: "cert", privateKey: "privateKey", publicKey: "publicKey" },
+      port: 1,
+      insecurePort: 2,
+      enableInsecureServer: false,
+    };
+    // @ts-ignore: the Obsidian App mock does not implement every App member.
+    handler = new RequestHandler(new App(), new PluginManifest(), settings);
+    handler.setupRouter();
+    server = http.createServer(handler.api);
+  });
+
+  afterEach(() => {
+    handler.mcpHandler.close();
+    server.close();
+  });
+
+  function authed(method: "post" | "get" | "delete", path = "/mcp/") {
+    return request(server)[method](path).set("Authorization", `Bearer ${API_KEY}`);
+  }
+
+  describe("middleware order", () => {
+    test("authentication is checked before the protocol version filter", async () => {
+      // An unauthenticated request with a bad version must fail as 401, not 400: the
+      // version filter must never run for a caller that has not proven itself.
+      await request(server)
+        .post("/mcp/")
+        .set("MCP-Protocol-Version", "9999-01-01")
+        .send(modernBody(1, "tools/list"))
+        .expect(401);
+    });
+
+    test("an unrecognised version on a modern-shaped request is answered by the SDK with -32022", async () => {
+      const res = await authed("post")
+        .set("MCP-Protocol-Version", "2026-07-29")
+        .set("Mcp-Method", "tools/list")
+        .send(
+          modernBody(1, "tools/list", {}, {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-29",
+          }),
+        )
+        .expect(400);
+
+      expect(res.body.error.code).toBe(-32022);
+      expect(res.body.error.data.supported).toContain(MODERN_VERSION);
+    });
+
+    test("an unrecognised version on a POST reaches the SDK, which names what is missing", async () => {
+      // The SDK classifies any POST whose version header it does not recognise as
+      // modern-shaped, so that the modern validation ladder — not a bare `{error}` body —
+      // gets to answer. A body with no envelope is -32602; one claiming the unknown
+      // revision is -32022 (covered above).
+      const res = await authed("post")
+        .set("MCP-Protocol-Version", "9999-01-01")
+        .send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })
+        .expect(400);
+
+      expect(res.body.jsonrpc).toBe("2.0");
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    test("a body-less session operation with an unrecognised version keeps the router's plain rejection", async () => {
+      for (const method of ["get", "delete"] as const) {
+        const res = await authed(method)
+          .set("MCP-Protocol-Version", "9999-01-01")
+          .expect(400);
+
+        expect(res.body.error).toMatch(/Unsupported MCP-Protocol-Version: 9999-01-01/);
+        expect(res.body.jsonrpc).toBeUndefined();
+      }
+    });
+  });
+
+  describe("modern leg", () => {
+    test("serves tools/call with no session and mints no session id", async () => {
+      const res = await authed("post")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/call")
+        .set("Mcp-Name", "tag_list")
+        .send(modernBody(1, "tools/call", { name: "tag_list", arguments: {} }))
+        .expect(200);
+
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+      expect(res.body.result.resultType).toBe("complete");
+    });
+
+    test("serves server/discover", async () => {
+      const res = await authed("post")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "server/discover")
+        .send(modernBody(1, "server/discover"))
+        .expect(200);
+
+      expect(res.body.result.supportedVersions).toContain(MODERN_VERSION);
+    });
+  });
+
+  describe("legacy leg", () => {
+    async function initialize(): Promise<string> {
+      const res = await authed("post")
+        .set("Accept", "application/json, text/event-stream")
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: LEGACY_VERSION,
+            capabilities: {},
+            clientInfo: { name: "legacy-client", version: "1.0.0" },
+          },
+        })
+        .expect(200);
+      const sessionId = res.headers["mcp-session-id"];
+      expect(typeof sessionId).toBe("string");
+      return sessionId;
+    }
+
+    test("initialize opens a session and later requests reuse it", async () => {
+      const sessionId = await initialize();
+      const res = await authed("post")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
+        .expect(200);
+
+      expect(sseResult(res.text).result.tools).toHaveLength(16);
+    });
+
+    test("an unknown session id is rejected with 404", async () => {
+      const res = await authed("post")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", "a-session-that-never-existed")
+        .send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })
+        .expect(404);
+
+      expect(res.body.error).toMatch(/Session not found/);
+    });
+  });
+});

--- a/src/mcpEndpoint.test.ts
+++ b/src/mcpEndpoint.test.ts
@@ -8,7 +8,7 @@ import { App, PluginManifest } from "../mocks/obsidian";
 // The mounted `/mcp/` endpoint, wired through the real RequestHandler *and* the real
 // McpHandler. requestHandler.test.ts mocks McpHandler, which means it cannot show what
 // the router's middleware order does to a real request: whether an unrecognised protocol
-// version is answered by the router or reaches the SDK, and whether the modern and legacy
+// version is answered by the router or reaches the SDK, and whether the sessionless and sessionful
 // legs are picked correctly, are both decided by that order.
 
 const API_KEY = "my api key";
@@ -24,7 +24,7 @@ function envelope(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function modernBody(
+function sessionlessBody(
   id: number,
   method: string,
   params: Record<string, unknown> = {},
@@ -38,7 +38,7 @@ function modernBody(
   };
 }
 
-// Read the JSON-RPC message out of a legacy SSE response.
+// Read the JSON-RPC message out of a sessionful-leg SSE response.
 function sseResult(text: string) {
   const line = text.split("\n").find((l) => l.startsWith("data: "));
   if (!line) throw new Error(`No SSE data frame in response: ${text}`);
@@ -79,16 +79,16 @@ describe("mounted /mcp/ endpoint", () => {
       await request(server)
         .post("/mcp/")
         .set("MCP-Protocol-Version", "9999-01-01")
-        .send(modernBody(1, "tools/list"))
+        .send(sessionlessBody(1, "tools/list"))
         .expect(401);
     });
 
-    test("an unrecognised version on a modern-shaped request is answered by the SDK with -32022", async () => {
+    test("an unrecognised version on a sessionless-shaped request is answered by the SDK with -32022", async () => {
       const res = await authed("post")
         .set("MCP-Protocol-Version", "2026-07-29")
         .set("Mcp-Method", "tools/list")
         .send(
-          modernBody(1, "tools/list", {}, {
+          sessionlessBody(1, "tools/list", {}, {
             "io.modelcontextprotocol/protocolVersion": "2026-07-29",
           }),
         )
@@ -100,7 +100,7 @@ describe("mounted /mcp/ endpoint", () => {
 
     test("an unrecognised version on a POST reaches the SDK, which names what is missing", async () => {
       // The SDK classifies any POST whose version header it does not recognise as
-      // modern-shaped, so that the modern validation ladder — not a bare `{error}` body —
+      // sessionless-shaped, so that the SDK's validation ladder — not a bare `{error}` body —
       // gets to answer. A body with no envelope is -32602; one claiming the unknown
       // revision is -32022 (covered above).
       const res = await authed("post")
@@ -124,14 +124,14 @@ describe("mounted /mcp/ endpoint", () => {
     });
   });
 
-  describe("modern leg", () => {
+  describe("sessionless leg", () => {
     test("serves tools/call with no session and mints no session id", async () => {
       const res = await authed("post")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/call")
         .set("Mcp-Name", "tag_list")
-        .send(modernBody(1, "tools/call", { name: "tag_list", arguments: {} }))
+        .send(sessionlessBody(1, "tools/call", { name: "tag_list", arguments: {} }))
         .expect(200);
 
       expect(res.headers["mcp-session-id"]).toBeUndefined();
@@ -143,14 +143,14 @@ describe("mounted /mcp/ endpoint", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "server/discover")
-        .send(modernBody(1, "server/discover"))
+        .send(sessionlessBody(1, "server/discover"))
         .expect(200);
 
       expect(res.body.result.supportedVersions).toContain(MODERN_VERSION);
     });
   });
 
-  describe("legacy leg", () => {
+  describe("sessionful leg", () => {
     async function initialize(): Promise<string> {
       const res = await authed("post")
         .set("Accept", "application/json, text/event-stream")
@@ -161,7 +161,7 @@ describe("mounted /mcp/ endpoint", () => {
           params: {
             protocolVersion: LEGACY_VERSION,
             capabilities: {},
-            clientInfo: { name: "legacy-client", version: "1.0.0" },
+            clientInfo: { name: "sessionful-client", version: "1.0.0" },
           },
         })
         .expect(200);

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -139,7 +139,7 @@ function makeApp(mcp: McpHandler) {
   return app;
 }
 
-function modernEnvelope(overrides: Record<string, unknown> = {}) {
+function sessionlessEnvelope(overrides: Record<string, unknown> = {}) {
   return {
     "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
     "io.modelcontextprotocol/clientInfo": { name: "unit-test", version: "1.0.0" },
@@ -148,7 +148,7 @@ function modernEnvelope(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function modernRequest(
+function sessionlessRequest(
   id: number,
   method: string,
   params: Record<string, unknown> = {},
@@ -158,7 +158,7 @@ function modernRequest(
     jsonrpc: "2.0",
     id,
     method,
-    params: { ...params, _meta: modernEnvelope(envelopeOverrides) },
+    params: { ...params, _meta: sessionlessEnvelope(envelopeOverrides) },
   };
 }
 
@@ -1047,7 +1047,7 @@ describe("McpHandler", () => {
 
   // ---- handleRequest ------------------------------------------------------
 
-  describe("handleRequest — modern (2026-07-28) path", () => {
+  describe("handleRequest — sessionless (2026-07-28) path", () => {
     let mcp: McpHandler;
     let app: express.Express;
 
@@ -1067,7 +1067,7 @@ describe("McpHandler", () => {
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/call")
         .set("Mcp-Name", "vault_list")
-        .send(modernRequest(1, "tools/call", { name: "vault_list", arguments: { path: "some/dir" } }))
+        .send(sessionlessRequest(1, "tools/call", { name: "vault_list", arguments: { path: "some/dir" } }))
         .expect(200);
 
       expect(res.headers["mcp-session-id"]).toBeUndefined();
@@ -1084,7 +1084,7 @@ describe("McpHandler", () => {
           .set("Accept", "application/json, text/event-stream")
           .set("MCP-Protocol-Version", MODERN_VERSION)
           .set("Mcp-Method", "tools/list")
-          .send(modernRequest(id, "tools/list"))
+          .send(sessionlessRequest(id, "tools/list"))
           .expect(200);
 
       const first = await send(1);
@@ -1095,13 +1095,13 @@ describe("McpHandler", () => {
       expect(second.headers["mcp-session-id"]).toBeUndefined();
     });
 
-    test("server/discover advertises the modern revision, capabilities, and server identity", async () => {
+    test("server/discover advertises the 2026-07-28 revision, capabilities, and server identity", async () => {
       const res = await request(app)
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "server/discover")
-        .send(modernRequest(1, "server/discover"))
+        .send(sessionlessRequest(1, "server/discover"))
         .expect(200);
 
       expect(res.body.result.supportedVersions).toContain(MODERN_VERSION);
@@ -1120,7 +1120,7 @@ describe("McpHandler", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "server/discover")
-        .send(modernRequest(1, "server/discover"))
+        .send(sessionlessRequest(1, "server/discover"))
         .expect(200);
       expect(discover.body.result.ttlMs).toBe(300_000);
       expect(discover.body.result.cacheScope).toBe("private");
@@ -1130,7 +1130,7 @@ describe("McpHandler", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/list")
-        .send(modernRequest(2, "tools/list"))
+        .send(sessionlessRequest(2, "tools/list"))
         .expect(200);
       expect(tools.body.result.ttlMs).toBe(60_000);
       expect(tools.body.result.cacheScope).toBe("private");
@@ -1140,7 +1140,7 @@ describe("McpHandler", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "resources/list")
-        .send(modernRequest(3, "resources/list"))
+        .send(sessionlessRequest(3, "resources/list"))
         .expect(200);
       expect(resources.body.result.ttlMs).toBe(60_000);
       expect(resources.body.result.cacheScope).toBe("private");
@@ -1154,7 +1154,7 @@ describe("McpHandler", () => {
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "resources/read")
         .set("Mcp-Name", uri)
-        .send(modernRequest(1, "resources/read", { uri }))
+        .send(sessionlessRequest(1, "resources/read", { uri }))
         .expect(200);
 
       expect(res.body.result.contents[0].mimeType).toBe("application/yaml");
@@ -1167,7 +1167,7 @@ describe("McpHandler", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/call")
-        .send(modernRequest(1, "tools/list"))
+        .send(sessionlessRequest(1, "tools/list"))
         .expect(400);
 
       expect(res.body.error.code).toBe(-32020);
@@ -1178,7 +1178,7 @@ describe("McpHandler", () => {
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
-        .send(modernRequest(1, "tools/list"))
+        .send(sessionlessRequest(1, "tools/list"))
         .expect(400);
 
       expect(res.body.error.code).toBe(-32020);
@@ -1191,7 +1191,7 @@ describe("McpHandler", () => {
         .set("MCP-Protocol-Version", "2027-01-01")
         .set("Mcp-Method", "tools/list")
         .send(
-          modernRequest(1, "tools/list", {}, {
+          sessionlessRequest(1, "tools/list", {}, {
             "io.modelcontextprotocol/protocolVersion": "2027-01-01",
           }),
         )
@@ -1227,7 +1227,7 @@ describe("McpHandler", () => {
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/list")
         .set("Mcp-Session-Id", "a-session-that-never-existed")
-        .send(modernRequest(1, "tools/list"))
+        .send(sessionlessRequest(1, "tools/list"))
         .expect(200);
 
       expect(res.body.result.tools).toHaveLength(16);
@@ -1241,7 +1241,7 @@ describe("McpHandler", () => {
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", MODERN_VERSION)
         .set("Mcp-Method", "tools/list")
-        .send(modernRequest(1, "tools/list"))
+        .send(sessionlessRequest(1, "tools/list"))
         .expect(200);
 
       const names = (res.body.result.tools as { name: string }[]).map((t) => t.name);
@@ -1249,7 +1249,7 @@ describe("McpHandler", () => {
     });
   });
 
-  describe("handleRequest — legacy (2025-era) path", () => {
+  describe("handleRequest — sessionful (2024-10-07 … 2025-11-25) path", () => {
     let mcp: McpHandler;
     let app: express.Express;
 
@@ -1262,7 +1262,7 @@ describe("McpHandler", () => {
       mcp.close();
     });
 
-    // The legacy leg answers on an SSE stream, so responses are read out of the
+    // The sessionful leg answers on an SSE stream, so responses are read out of the
     // `event: message` frames rather than from a JSON body.
     function sseResult(text: string) {
       const line = text.split("\n").find((l) => l.startsWith("data: "));
@@ -1281,18 +1281,18 @@ describe("McpHandler", () => {
           params: {
             protocolVersion: LEGACY_VERSION,
             capabilities: {},
-            clientInfo: { name: "legacy-client", version: "1.0.0" },
+            clientInfo: { name: "sessionful-client", version: "1.0.0" },
           },
         })
         .expect(200);
       return { sessionId: res.headers["mcp-session-id"], result: sseResult(res.text).result };
     }
 
-    test("still answers the initialize handshake for pre-2026 clients", async () => {
+    test("answers the initialize handshake for sessionful clients", async () => {
       const { result } = await initialize();
       expect(result.protocolVersion).toBe(LEGACY_VERSION);
       expect(result.serverInfo.name).toBe("obsidian-local-rest-api");
-      // 2025-era results carry no 2026 wire fields.
+      // Sessionful-leg results carry none of the 2026-07-28 wire fields.
       expect(result.resultType).toBeUndefined();
       expect(result.ttlMs).toBeUndefined();
     });
@@ -1304,7 +1304,7 @@ describe("McpHandler", () => {
     });
 
     test("advertises listChanged capabilities it can actually honour", async () => {
-      // The legacy leg is sessionful precisely so that this advertisement stays true: a
+      // The sessionful leg keeps sessions precisely so that this advertisement stays true: a
       // client told `listChanged: true` waits for notifications instead of re-polling.
       const { result } = await initialize();
       expect(result.capabilities.tools.listChanged).toBe(true);
@@ -1330,7 +1330,7 @@ describe("McpHandler", () => {
       expect(JSON.parse(message.result.content[0].text).files).toEqual(["file1.md", "folder/"]);
     });
 
-    test("advertises the same tool list as the modern path", async () => {
+    test("advertises the same tool list as the sessionless leg", async () => {
       const { sessionId } = await initialize();
       const res = await request(app)
         .post("/mcp/")
@@ -1381,11 +1381,11 @@ describe("McpHandler", () => {
       expect(sseResult(called.text).result.content[0].text).toBe("hi");
     });
 
-    test("registering a tool notifies live legacy sessions", async () => {
+    test("registering a tool notifies live sessions", async () => {
       const { sessionId } = await initialize();
       const session = [...(mcp as unknown as {
-        legacySessions: Map<string, { server: { sendToolListChanged: () => void } }>;
-      }).legacySessions.values()][0];
+        sessions: Map<string, { server: { sendToolListChanged: () => void } }>;
+      }).sessions.values()][0];
       const sendToolListChanged = jest.spyOn(session.server, "sendToolListChanged");
 
       mcp.registerTool("notifying_tool", "From an extension", {}, async () => "hi");

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -1,14 +1,4 @@
 // jest.mock calls are hoisted before imports by ts-jest's babel transform.
-// Variables prefixed with "mock" are also hoisted, so they can be safely
-// referenced inside the factory functions below.
-
-const mockRemove = jest.fn();
-const mockTool = jest.fn().mockReturnValue({ remove: mockRemove });
-const mockConnect = jest.fn().mockResolvedValue(undefined);
-const mockTransportHandleRequest = jest.fn().mockResolvedValue(undefined);
-const mockNewSessionId = "new-session-id";
-
-const mockResource = jest.fn();
 
 // Prevent ts-jest from compiling vaultOperations.ts (which pulls in json-logic-js
 // with a deeply recursive RulesLogic type that OOMs TypeScript 4.7). The real
@@ -18,31 +8,23 @@ jest.mock("./vaultOperations", () => ({
   VaultOperations: jest.fn(),
 }));
 
-jest.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
-  McpServer: jest.fn().mockImplementation(() => ({
-    tool: mockTool,
-    resource: mockResource,
-    connect: mockConnect,
-  })),
-}));
-
-jest.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
-  StreamableHTTPServerTransport: jest.fn().mockImplementation((opts: { onsessioninitialized?: (id: string) => void }) => {
-    const transport = {
-      sessionId: mockNewSessionId,
-      handleRequest: mockTransportHandleRequest,
-      onclose: undefined as (() => void) | undefined,
-    };
-    // Defer so the outer `const transport = new ...` assignment completes first,
-    // matching the real SDK which only calls this after processing the initialize message.
-    void Promise.resolve().then(() => opts?.onsessioninitialized?.(mockNewSessionId));
-    return transport;
-  }),
-}));
+import express from "express";
+import request from "supertest";
+import { McpServer } from "@modelcontextprotocol/server";
 
 import { McpHandler } from "./mcpHandler";
 import { DEFAULT_SETTINGS } from "./constants";
 import { TFile } from "../mocks/obsidian";
+
+const MODERN_VERSION = "2026-07-28";
+const LEGACY_VERSION = "2025-06-18";
+
+// The real McpServer is used throughout: the 2026-07-28 serving entries build one per
+// request from McpHandler's factory, so there is nothing to substitute. Registrations are
+// observed by spying on the prototype and then building a server directly.
+let registerTool: jest.SpyInstance;
+let registerResource: jest.SpyInstance;
+
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -118,24 +100,19 @@ function makeMockOps() {
 
 // Returns the callback registered for the named tool.
 function getToolCallback(toolName: string) {
-  const call = mockTool.mock.calls.find(
-    (c: unknown[]) => c[0] === toolName,
-  );
+  const call = registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
   if (!call) throw new Error(`Tool "${toolName}" was not registered`);
-  // tool(name, description, schema, annotations, callback) — callback is always last
-  return call[call.length - 1] as (args: Record<string, unknown>) => Promise<{
+  // registerTool(name, config, callback)
+  return call[2] as (args: Record<string, unknown>) => Promise<{
     content: Array<{ type: string; text: string }>;
   }>;
 }
 
 // Returns the annotations object registered for the named tool.
 function getToolAnnotations(toolName: string) {
-  const call = mockTool.mock.calls.find(
-    (c: unknown[]) => c[0] === toolName,
-  );
+  const call = registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
   if (!call) throw new Error(`Tool "${toolName}" was not registered`);
-  // tool(name, description, schema, annotations, callback) — annotations is second-to-last
-  return call[call.length - 2] as Record<string, boolean>;
+  return (call[1] as { annotations: Record<string, boolean> }).annotations;
 }
 
 function parseText(result: { content: Array<{ type: string; text: string }> }) {
@@ -149,6 +126,43 @@ function parseText(result: { content: Array<{ type: string; text: string }> }) {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP helpers — the endpoint is exercised through the same express wiring the
+// request handler mounts, so the SDK's Streamable HTTP behavior is under test too.
+// ---------------------------------------------------------------------------
+
+function makeApp(mcp: McpHandler) {
+  const app = express();
+  app.use(express.json());
+  app.all("/mcp/", (req, res, next) => {
+    mcp.handleRequest(req, res).catch(next);
+  });
+  return app;
+}
+
+function modernEnvelope(overrides: Record<string, unknown> = {}) {
+  return {
+    "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": { name: "unit-test", version: "1.0.0" },
+    "io.modelcontextprotocol/clientCapabilities": {},
+    ...overrides,
+  };
+}
+
+function modernRequest(
+  id: number,
+  method: string,
+  params: Record<string, unknown> = {},
+  envelopeOverrides: Record<string, unknown> = {},
+) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: { ...params, _meta: modernEnvelope(envelopeOverrides) },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -156,29 +170,30 @@ describe("McpHandler", () => {
    
   let ops: any;
 
-  // Each session now gets its own McpServer, so tool/resource registration runs when
-  // a session is built (not at construction). Trigger one build so the McpServer mock
-  // captures the registrations that getToolCallback() reads.
-  async function buildSession(mcp: McpHandler): Promise<void> {
-    // @ts-ignore: partial mock
-    await mcp.handleRequest(
-      { headers: {}, body: { jsonrpc: "2.0", id: 0, method: "initialize" } },
-      { status: jest.fn().mockReturnThis(), json: jest.fn() },
-    );
+  // Every request builds a fresh McpServer from the handler's specs, so tool and
+  // resource registration is observed by building one server directly.
+  function buildServer(mcp: McpHandler): void {
+    // @ts-ignore: buildServer is private — the test observes what a request would build.
+    mcp.buildServer();
   }
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
+  beforeEach(() => {
+    registerTool = jest.spyOn(McpServer.prototype, "registerTool");
+    registerResource = jest.spyOn(McpServer.prototype, "registerResource");
     ops = makeMockOps();
-    // Construction records specs; building a session registers them on a server.
-    await buildSession(new McpHandler(ops, DEFAULT_SETTINGS));
+    // Construction records specs; building a server registers them.
+    buildServer(new McpHandler(ops, DEFAULT_SETTINGS));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   // ---- resource registration ----------------------------------------------
 
   test("registers the openapi-spec resource", () => {
-    expect(mockResource).toHaveBeenCalledTimes(1);
-    const [name, uri] = mockResource.mock.calls[0] as [string, string];
+    expect(registerResource).toHaveBeenCalledTimes(1);
+    const [name, uri] = registerResource.mock.calls[0] as [string, string];
     expect(name).toBe("openapi-spec");
     expect(uri).toBe("obsidian://local-rest-api/openapi.yaml");
   });
@@ -186,8 +201,8 @@ describe("McpHandler", () => {
   // ---- tool registration --------------------------------------------------
 
   test("registers all 16 tools", () => {
-    expect(mockTool).toHaveBeenCalledTimes(16);
-    const names = mockTool.mock.calls.map((c: unknown[]) => c[0]);
+    expect(registerTool).toHaveBeenCalledTimes(16);
+    const names = registerTool.mock.calls.map((c: unknown[]) => c[0]);
     expect(names).toEqual(
       expect.arrayContaining([
         "vault_list",
@@ -242,8 +257,8 @@ describe("McpHandler", () => {
     });
 
     test("no tool is annotated openWorldHint true", () => {
-      for (const call of mockTool.mock.calls) {
-        const annotations = call[call.length - 2] as Record<string, boolean>;
+      for (const call of registerTool.mock.calls) {
+        const { annotations } = call[1] as { annotations: Record<string, boolean> };
         expect(annotations.openWorldHint).toBe(false);
       }
     });
@@ -1032,73 +1047,308 @@ describe("McpHandler", () => {
 
   // ---- handleRequest ------------------------------------------------------
 
-  describe("handleRequest", () => {
-    // Reset mock counts polluted by the outer beforeEach session build.
-    beforeEach(() => jest.clearAllMocks());
+  describe("handleRequest — modern (2026-07-28) path", () => {
+    let mcp: McpHandler;
+    let app: express.Express;
 
-    test("returns 404 when session ID is unknown", async () => {
-      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
-      const mockRes = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      };
-      // @ts-ignore: using partial mock
-      await mcp.handleRequest(
-        { headers: { "mcp-session-id": "unknown" } },
-        mockRes,
-      );
-      expect(mockRes.status).toHaveBeenCalledWith(404);
+    beforeEach(() => {
+      mcp = new McpHandler(ops, DEFAULT_SETTINGS);
+      app = makeApp(mcp);
     });
 
-    test("creates new transport and delegates when no session ID header", async () => {
-      const { StreamableHTTPServerTransport } = jest.requireMock(
-        "@modelcontextprotocol/sdk/server/streamableHttp.js",
-      );
-      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
-
-      const mockReq = { headers: {}, body: { jsonrpc: "2.0", method: "initialize" } };
-      const mockRes = {};
-      // @ts-ignore
-      await mcp.handleRequest(mockReq, mockRes);
-
-      expect(StreamableHTTPServerTransport).toHaveBeenCalledTimes(1);
-      expect(mockConnect).toHaveBeenCalledTimes(1);
-      const transport = StreamableHTTPServerTransport.mock.results[0].value;
-      expect(transport.handleRequest).toHaveBeenCalledWith(mockReq, mockRes, mockReq.body);
+    afterEach(() => {
+      mcp.close();
     });
 
-    test("delegates to existing transport when session ID matches", async () => {
-      const { StreamableHTTPServerTransport } = jest.requireMock(
-        "@modelcontextprotocol/sdk/server/streamableHttp.js",
+    test("answers tools/call without any session, and mints no session id", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/call")
+        .set("Mcp-Name", "vault_list")
+        .send(modernRequest(1, "tools/call", { name: "vault_list", arguments: { path: "some/dir" } }))
+        .expect(200);
+
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+      expect(res.body.error).toBeUndefined();
+      expect(res.body.result.resultType).toBe("complete");
+      expect(JSON.parse(res.body.result.content[0].text).files).toEqual(["file1.md", "folder/"]);
+      expect(ops.listVaultDirectory).toHaveBeenCalledWith("some/dir");
+    });
+
+    test("serves consecutive requests independently — no initialize, no session state", async () => {
+      const send = (id: number) =>
+        request(app)
+          .post("/mcp/")
+          .set("Accept", "application/json, text/event-stream")
+          .set("MCP-Protocol-Version", MODERN_VERSION)
+          .set("Mcp-Method", "tools/list")
+          .send(modernRequest(id, "tools/list"))
+          .expect(200);
+
+      const first = await send(1);
+      const second = await send(2);
+      expect(first.body.result.tools).toHaveLength(16);
+      expect(second.body.result.tools).toHaveLength(16);
+      expect(first.headers["mcp-session-id"]).toBeUndefined();
+      expect(second.headers["mcp-session-id"]).toBeUndefined();
+    });
+
+    test("server/discover advertises the modern revision, capabilities, and server identity", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "server/discover")
+        .send(modernRequest(1, "server/discover"))
+        .expect(200);
+
+      expect(res.body.result.supportedVersions).toContain(MODERN_VERSION);
+      expect(res.body.result.capabilities.tools).toBeDefined();
+      expect(res.body.result.capabilities.resources).toBeDefined();
+      expect(res.body.result.resultType).toBe("complete");
+      expect(res.body.result._meta["io.modelcontextprotocol/serverInfo"]).toEqual({
+        name: "obsidian-local-rest-api",
+        version: "1.0.0",
+      });
+    });
+
+    test("cacheable results carry the required ttlMs and cacheScope fields", async () => {
+      const discover = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "server/discover")
+        .send(modernRequest(1, "server/discover"))
+        .expect(200);
+      expect(discover.body.result.ttlMs).toBe(300_000);
+      expect(discover.body.result.cacheScope).toBe("private");
+
+      const tools = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/list")
+        .send(modernRequest(2, "tools/list"))
+        .expect(200);
+      expect(tools.body.result.ttlMs).toBe(60_000);
+      expect(tools.body.result.cacheScope).toBe("private");
+
+      const resources = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "resources/list")
+        .send(modernRequest(3, "resources/list"))
+        .expect(200);
+      expect(resources.body.result.ttlMs).toBe(60_000);
+      expect(resources.body.result.cacheScope).toBe("private");
+    });
+
+    test("reads the openapi-spec resource", async () => {
+      const uri = "obsidian://local-rest-api/openapi.yaml";
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "resources/read")
+        .set("Mcp-Name", uri)
+        .send(modernRequest(1, "resources/read", { uri }))
+        .expect(200);
+
+      expect(res.body.result.contents[0].mimeType).toBe("application/yaml");
+      expect(res.body.result.ttlMs).toBe(60_000);
+    });
+
+    test("rejects a request whose Mcp-Method header disagrees with the body (-32020)", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/call")
+        .send(modernRequest(1, "tools/list"))
+        .expect(400);
+
+      expect(res.body.error.code).toBe(-32020);
+    });
+
+    test("rejects a request with no Mcp-Method header (-32020)", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .send(modernRequest(1, "tools/list"))
+        .expect(400);
+
+      expect(res.body.error.code).toBe(-32020);
+    });
+
+    test("rejects an unsupported protocol version with -32022 and names what it serves", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", "2027-01-01")
+        .set("Mcp-Method", "tools/list")
+        .send(
+          modernRequest(1, "tools/list", {}, {
+            "io.modelcontextprotocol/protocolVersion": "2027-01-01",
+          }),
+        )
+        .expect(400);
+
+      expect(res.body.error.code).toBe(-32022);
+      expect(res.body.error.data.supported).toContain(MODERN_VERSION);
+    });
+
+    test("rejects a malformed _meta envelope with -32602", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/list")
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {
+            _meta: { "io.modelcontextprotocol/protocolVersion": MODERN_VERSION },
+          },
+        })
+        .expect(400);
+
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    test("tools registered after construction are served on the next request", async () => {
+      mcp.registerTool("extension_tool", "From an extension", {}, async () => "hi");
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/list")
+        .send(modernRequest(1, "tools/list"))
+        .expect(200);
+
+      const names = (res.body.result.tools as { name: string }[]).map((t) => t.name);
+      expect(names).toContain("extension_tool");
+    });
+  });
+
+  describe("handleRequest — legacy (2025-era) path", () => {
+    let mcp: McpHandler;
+    let app: express.Express;
+
+    beforeEach(() => {
+      mcp = new McpHandler(ops, DEFAULT_SETTINGS);
+      app = makeApp(mcp);
+    });
+
+    afterEach(() => {
+      mcp.close();
+    });
+
+    // The legacy leg answers on an SSE stream, so responses are read out of the
+    // `event: message` frames rather than from a JSON body.
+    function sseResult(text: string) {
+      const line = text.split("\n").find((l) => l.startsWith("data: "));
+      if (!line) throw new Error(`No SSE data frame in response: ${text}`);
+      return JSON.parse(line.slice("data: ".length));
+    }
+
+    test("still answers the initialize handshake for pre-2026 clients", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: LEGACY_VERSION,
+            capabilities: {},
+            clientInfo: { name: "legacy-client", version: "1.0.0" },
+          },
+        })
+        .expect(200);
+
+      const message = sseResult(res.text);
+      expect(message.result.protocolVersion).toBe(LEGACY_VERSION);
+      expect(message.result.serverInfo.name).toBe("obsidian-local-rest-api");
+      // 2025-era results carry no 2026 wire fields.
+      expect(message.result.resultType).toBeUndefined();
+      expect(message.result.ttlMs).toBeUndefined();
+    });
+
+    test("serves tools/call for a legacy client without a session id", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .send({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "vault_list", arguments: { path: "some/dir" } },
+        })
+        .expect(200);
+
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+      const message = sseResult(res.text);
+      expect(JSON.parse(message.result.content[0].text).files).toEqual(["file1.md", "folder/"]);
+    });
+
+    test("advertises the same tool list as the modern path", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .send({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })
+        .expect(200);
+
+      const message = sseResult(res.text);
+      expect(message.result.tools).toHaveLength(16);
+      const vaultList = (message.result.tools as { name: string; inputSchema: unknown }[]).find(
+        (t) => t.name === "vault_list",
       );
-      const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
+      expect(vaultList?.inputSchema).toMatchObject({
+        type: "object",
+        properties: { path: { type: "string" } },
+      });
+    });
 
-      // Initialize: POST without session ID registers the transport via onsessioninitialized
-      const initReq = { headers: {}, body: undefined };
-      const initRes = {};
-      // @ts-ignore
-      await mcp.handleRequest(initReq, initRes);
+    test("answers the removed GET stream and DELETE session operations with 405", async () => {
+      await request(app).get("/mcp/").set("Accept", "text/event-stream").expect(405);
+      await request(app).delete("/mcp/").expect(405);
+    });
 
-      // Subsequent request with the assigned session ID
-      const mockReq2 = { headers: { "mcp-session-id": mockNewSessionId } };
-      const mockRes2 = {};
-      // @ts-ignore
-      await mcp.handleRequest(mockReq2, mockRes2);
+    test("no longer routes on Mcp-Session-Id — an unknown session id is served, not 404ed", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", "a-session-that-never-existed")
+        .send({ jsonrpc: "2.0", id: 4, method: "tools/list", params: {} })
+        .expect(200);
 
-      const transport = StreamableHTTPServerTransport.mock.results[0].value;
-      expect(transport.handleRequest).toHaveBeenCalledTimes(2);
-      expect(transport.handleRequest).toHaveBeenLastCalledWith(mockReq2, mockRes2, undefined);
+      const message = sseResult(res.text);
+      expect(message.result.tools).toHaveLength(16);
     });
   });
 
   // ---- registerTool -------------------------------------------------------
 
   describe("registerTool", () => {
-    test("registers a tool and returns a cleanup function", async () => {
+    test("registers a tool and returns a cleanup function", () => {
       const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
       const cleanup = mcp.registerTool("my_tool", "Does something", {}, async () => "result");
-      await buildSession(mcp);
-      expect(mockTool).toHaveBeenCalledWith("my_tool", "Does something", {}, {}, expect.any(Function));
+      registerTool.mockClear();
+      buildServer(mcp);
+      expect(registerTool).toHaveBeenCalledWith(
+        "my_tool",
+        expect.objectContaining({ description: "Does something", annotations: {} }),
+        expect.any(Function),
+      );
       expect(typeof cleanup).toBe("function");
     });
 
@@ -1117,7 +1367,7 @@ describe("McpHandler", () => {
       ).toThrow(/already registered/);
     });
 
-    test("cleanup removes the tool and frees the name for re-registration", async () => {
+    test("cleanup removes the tool and frees the name for re-registration", () => {
       const mcp = new McpHandler(ops, DEFAULT_SETTINGS);
       const cleanup = mcp.registerTool("removable_tool", "Desc", {}, async () => "");
       cleanup();
@@ -1126,9 +1376,9 @@ describe("McpHandler", () => {
         mcp.registerTool("removable_tool", "Desc", {}, async () => ""),
       ).not.toThrow();
       // ...and the cleaned-up spec is not double-registered on a fresh server.
-      jest.clearAllMocks();
-      await buildSession(mcp);
-      const removableCalls = mockTool.mock.calls.filter((c: unknown[]) => c[0] === "removable_tool");
+      registerTool.mockClear();
+      buildServer(mcp);
+      const removableCalls = registerTool.mock.calls.filter((c: unknown[]) => c[0] === "removable_tool");
       expect(removableCalls).toHaveLength(1);
     });
   });

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -1220,6 +1220,20 @@ describe("McpHandler", () => {
       expect(res.body.error.code).toBe(-32602);
     });
 
+    test("ignores a stale Mcp-Session-Id header rather than routing on it", async () => {
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", MODERN_VERSION)
+        .set("Mcp-Method", "tools/list")
+        .set("Mcp-Session-Id", "a-session-that-never-existed")
+        .send(modernRequest(1, "tools/list"))
+        .expect(200);
+
+      expect(res.body.result.tools).toHaveLength(16);
+      expect(res.headers["mcp-session-id"]).toBeUndefined();
+    });
+
     test("tools registered after construction are served on the next request", async () => {
       mcp.registerTool("extension_tool", "From an extension", {}, async () => "hi");
       const res = await request(app)
@@ -1256,7 +1270,7 @@ describe("McpHandler", () => {
       return JSON.parse(line.slice("data: ".length));
     }
 
-    test("still answers the initialize handshake for pre-2026 clients", async () => {
+    async function initialize(): Promise<{ sessionId: string; result: any }> {
       const res = await request(app)
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
@@ -1271,20 +1285,39 @@ describe("McpHandler", () => {
           },
         })
         .expect(200);
+      return { sessionId: res.headers["mcp-session-id"], result: sseResult(res.text).result };
+    }
 
-      const message = sseResult(res.text);
-      expect(message.result.protocolVersion).toBe(LEGACY_VERSION);
-      expect(message.result.serverInfo.name).toBe("obsidian-local-rest-api");
+    test("still answers the initialize handshake for pre-2026 clients", async () => {
+      const { result } = await initialize();
+      expect(result.protocolVersion).toBe(LEGACY_VERSION);
+      expect(result.serverInfo.name).toBe("obsidian-local-rest-api");
       // 2025-era results carry no 2026 wire fields.
-      expect(message.result.resultType).toBeUndefined();
-      expect(message.result.ttlMs).toBeUndefined();
+      expect(result.resultType).toBeUndefined();
+      expect(result.ttlMs).toBeUndefined();
     });
 
-    test("serves tools/call for a legacy client without a session id", async () => {
+    test("initialize opens a session and hands back its id", async () => {
+      const { sessionId } = await initialize();
+      expect(typeof sessionId).toBe("string");
+      expect(sessionId.length).toBeGreaterThan(0);
+    });
+
+    test("advertises listChanged capabilities it can actually honour", async () => {
+      // The legacy leg is sessionful precisely so that this advertisement stays true: a
+      // client told `listChanged: true` waits for notifications instead of re-polling.
+      const { result } = await initialize();
+      expect(result.capabilities.tools.listChanged).toBe(true);
+      expect(result.capabilities.resources.listChanged).toBe(true);
+    });
+
+    test("serves tools/call on an established session", async () => {
+      const { sessionId } = await initialize();
       const res = await request(app)
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
         .send({
           jsonrpc: "2.0",
           id: 2,
@@ -1293,16 +1326,17 @@ describe("McpHandler", () => {
         })
         .expect(200);
 
-      expect(res.headers["mcp-session-id"]).toBeUndefined();
       const message = sseResult(res.text);
       expect(JSON.parse(message.result.content[0].text).files).toEqual(["file1.md", "folder/"]);
     });
 
     test("advertises the same tool list as the modern path", async () => {
+      const { sessionId } = await initialize();
       const res = await request(app)
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
         .send({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })
         .expect(200);
 
@@ -1317,22 +1351,102 @@ describe("McpHandler", () => {
       });
     });
 
-    test("answers the removed GET stream and DELETE session operations with 405", async () => {
-      await request(app).get("/mcp/").set("Accept", "text/event-stream").expect(405);
-      await request(app).delete("/mcp/").expect(405);
+    test("a tool registered after the handshake is visible to the live session", async () => {
+      const { sessionId } = await initialize();
+      mcp.registerTool("extension_tool", "From an extension", {}, async () => "hi");
+
+      const listed = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({ jsonrpc: "2.0", id: 4, method: "tools/list", params: {} })
+        .expect(200);
+
+      const names = (sseResult(listed.text).result.tools as { name: string }[]).map((t) => t.name);
+      expect(names).toContain("extension_tool");
+
+      const called = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: { name: "extension_tool", arguments: {} },
+        })
+        .expect(200);
+      expect(sseResult(called.text).result.content[0].text).toBe("hi");
     });
 
-    test("no longer routes on Mcp-Session-Id — an unknown session id is served, not 404ed", async () => {
+    test("registering a tool notifies live legacy sessions", async () => {
+      const { sessionId } = await initialize();
+      const session = [...(mcp as unknown as {
+        legacySessions: Map<string, { server: { sendToolListChanged: () => void } }>;
+      }).legacySessions.values()][0];
+      const sendToolListChanged = jest.spyOn(session.server, "sendToolListChanged");
+
+      mcp.registerTool("notifying_tool", "From an extension", {}, async () => "hi");
+
+      expect(sendToolListChanged).toHaveBeenCalled();
+      expect(sessionId).toBeTruthy();
+    });
+
+    test("a tool removed after the handshake disappears from the live session", async () => {
+      const { sessionId } = await initialize();
+      const cleanup = mcp.registerTool("temporary_tool", "Goes away", {}, async () => "hi");
+      cleanup();
+
+      const res = await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({ jsonrpc: "2.0", id: 6, method: "tools/list", params: {} })
+        .expect(200);
+
+      const names = (sseResult(res.text).result.tools as { name: string }[]).map((t) => t.name);
+      expect(names).not.toContain("temporary_tool");
+    });
+
+    test("an unknown session id is rejected with 404", async () => {
       const res = await request(app)
         .post("/mcp/")
         .set("Accept", "application/json, text/event-stream")
         .set("MCP-Protocol-Version", LEGACY_VERSION)
         .set("Mcp-Session-Id", "a-session-that-never-existed")
-        .send({ jsonrpc: "2.0", id: 4, method: "tools/list", params: {} })
-        .expect(200);
+        .send({ jsonrpc: "2.0", id: 7, method: "tools/list", params: {} })
+        .expect(404);
 
-      const message = sseResult(res.text);
-      expect(message.result.tools).toHaveLength(16);
+      expect(res.body.error).toMatch(/Session not found/);
+    });
+
+    test("DELETE terminates the session, and later requests on it are 404ed", async () => {
+      const { sessionId } = await initialize();
+      await request(app).delete("/mcp/").set("Mcp-Session-Id", sessionId).expect(200);
+
+      await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({ jsonrpc: "2.0", id: 8, method: "tools/list", params: {} })
+        .expect(404);
+    });
+
+    test("close() drops every open session", async () => {
+      const { sessionId } = await initialize();
+      mcp.close();
+
+      await request(app)
+        .post("/mcp/")
+        .set("Accept", "application/json, text/event-stream")
+        .set("MCP-Protocol-Version", LEGACY_VERSION)
+        .set("Mcp-Session-Id", sessionId)
+        .send({ jsonrpc: "2.0", id: 9, method: "tools/list", params: {} })
+        .expect(404);
     });
   });
 

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -1,15 +1,17 @@
-import { McpServer, createMcpHandler, isLegacyRequest, legacyStatelessFallback } from "@modelcontextprotocol/server";
+import { McpServer, createMcpHandler, isLegacyRequest } from "@modelcontextprotocol/server";
 import type {
   CacheHint,
   CallToolResult,
   McpHttpHandler,
   ReadResourceResult,
+  RegisteredTool,
   StandardSchemaWithJSON,
   ToolAnnotations,
 } from "@modelcontextprotocol/server";
-import { toNodeHandler, toWebRequest } from "@modelcontextprotocol/node";
+import { NodeStreamableHTTPServerTransport, toNodeHandler, toWebRequest } from "@modelcontextprotocol/node";
 import type { NodeMcpRequestHandler } from "@modelcontextprotocol/node";
 import { posix } from "path";
+import { randomUUID } from "crypto";
 import { z } from "zod";
 import express from "express";
 import { TFile } from "obsidian";
@@ -85,6 +87,17 @@ interface ResourceSpec {
   handler: (uri: URL) => Promise<ReadResourceResult>;
 }
 
+/**
+ * A live 2025-era session: one client's `initialize` handshake, the server instance
+ * pinned to it, and the handles needed to add or drop tools on that instance while it
+ * is connected. Modern requests never produce one of these.
+ */
+interface LegacySession {
+  server: McpServer;
+  transport: NodeStreamableHTTPServerTransport;
+  toolHandles: Map<string, RegisteredTool>;
+}
+
 export class McpHandler {
   // The tool and resource registries are this handler's application state: the 2026-07-28
   // revision has no protocol-level session to hang anything off, so everything a request
@@ -98,31 +111,36 @@ export class McpHandler {
   // 2025-era traffic is handed to the separate legacy leg below by `handleRequest`.
   private readonly modernHandler: McpHttpHandler;
   private readonly modernNodeHandler: NodeMcpRequestHandler;
+
   // The legacy (2024-10-07 … 2025-11-25) leg, kept deliberately separate from the modern
-  // one so that older clients — which still open with an `initialize` handshake — keep
-  // working unchanged. It is the SDK's own stateless 2025-era serving, so it too holds no
-  // per-session state; the `Mcp-Session-Id` routing this handler used to do is gone.
-  private readonly legacyNodeHandler: NodeMcpRequestHandler;
+  // one. It stays *sessionful*, because that is what those revisions are: a client opens
+  // with `initialize`, the server answers with an `Mcp-Session-Id`, and the capabilities
+  // it advertises — including `tools.listChanged` — promise a live notification channel
+  // for the rest of the session. Serving those clients statelessly would make that
+  // promise a lie and leave a tool an extension registers invisible until the client
+  // happened to re-poll. The session map therefore lives here and only here; the modern
+  // leg neither issues nor reads `Mcp-Session-Id`.
+  private readonly legacySessions: Map<string, LegacySession> = new Map();
 
   constructor(
     private readonly ops: VaultOperations,
     private readonly settings: LocalRestApiSettings,
   ) {
-    const factory = () => this.buildServer();
     const onerror = (error: Error) => this.logHandlerError(error);
-    this.modernHandler = createMcpHandler(factory, { legacy: "reject", onerror });
+    this.modernHandler = createMcpHandler(() => this.buildServer().server, {
+      legacy: "reject",
+      onerror,
+    });
     this.modernNodeHandler = toNodeHandler(this.modernHandler, { onerror });
-    this.legacyNodeHandler = toNodeHandler(
-      { fetch: legacyStatelessFallback(factory, onerror) },
-      { onerror },
-    );
     this.registerResources();
     this.registerTools();
   }
 
-  // Build a fresh McpServer for a single request. Both legs are per-request by
-  // construction, so a server instance is never shared between two exchanges.
-  private buildServer(): McpServer {
+  // Build a fresh McpServer from the current specs. The modern leg discards the tool
+  // handles (it builds one server per request, so nothing outlives the exchange); the
+  // legacy leg keeps them, because its server stays connected for a whole session and
+  // has to learn about tools registered after the handshake.
+  private buildServer(): { server: McpServer; toolHandles: Map<string, RegisteredTool> } {
     const server = new McpServer(SERVER_INFO, {
       capabilities: { tools: {}, resources: {} },
       cacheHints: CACHE_HINTS,
@@ -130,18 +148,23 @@ export class McpHandler {
     for (const spec of this.resourceSpecs) {
       server.registerResource(spec.name, spec.uri, spec.meta, spec.handler);
     }
+    const toolHandles = new Map<string, RegisteredTool>();
     for (const spec of this.toolSpecs.values()) {
-      server.registerTool(
-        spec.name,
-        {
-          description: spec.description,
-          inputSchema: spec.inputSchema,
-          annotations: spec.annotations,
-        },
-        spec.callback,
-      );
+      toolHandles.set(spec.name, this.registerToolOn(server, spec));
     }
-    return server;
+    return { server, toolHandles };
+  }
+
+  private registerToolOn(server: McpServer, spec: ToolSpec): RegisteredTool {
+    return server.registerTool(
+      spec.name,
+      {
+        description: spec.description,
+        inputSchema: spec.inputSchema,
+        annotations: spec.annotations,
+      },
+      spec.callback,
+    );
   }
 
   private logHandlerError(error: Error): void {
@@ -178,11 +201,20 @@ export class McpHandler {
       },
     };
     this.toolSpecs.set(spec.name, spec);
+    // Modern clients learn about the change through a `subscriptions/listen` stream;
+    // legacy sessions are live server instances, so the tool is registered on each of
+    // them, which is what emits `notifications/tools/list_changed` on their stream.
     this.modernHandler.notify.toolsChanged();
+    for (const session of this.legacySessions.values()) {
+      session.toolHandles.set(spec.name, this.registerToolOn(session.server, spec));
+    }
     return {
       remove: () => {
-        if (this.toolSpecs.delete(spec.name)) {
-          this.modernHandler.notify.toolsChanged();
+        if (!this.toolSpecs.delete(spec.name)) return;
+        this.modernHandler.notify.toolsChanged();
+        for (const session of this.legacySessions.values()) {
+          session.toolHandles.get(spec.name)?.remove();
+          session.toolHandles.delete(spec.name);
         }
       },
     };
@@ -207,33 +239,92 @@ export class McpHandler {
   }
 
   /**
-   * Serve one request on the MCP endpoint.
+   * Whether a request belongs to the modern (2026-07-28) leg.
    *
    * Classification is the SDK's own — `isLegacyRequest` runs exactly the code
-   * `createMcpHandler` runs — so the two legs can never disagree about who owns a
-   * request. Anything carrying the 2026-07-28 `_meta` envelope claim (including a claim
-   * naming a revision we do not serve, or a malformed one) belongs to the modern leg,
-   * which owns those error answers; everything else is 2025-era traffic.
+   * `createMcpHandler` runs — so nothing that branches on this can disagree with the
+   * entry about who owns a request. Anything carrying the 2026-07-28 `_meta` envelope
+   * claim is modern, including a claim naming a revision this server does not serve or a
+   * malformed one: the modern leg owns those error answers (`-32022` / `-32602`).
+   * Everything else — `initialize` handshakes, session GET/DELETE — is 2025-era traffic.
+   *
+   * `req.body` is passed explicitly because the router's `express.json()` has already
+   * drained the Node stream, which cannot be read a second time.
    */
+  public async isModernRequest(req: express.Request): Promise<boolean> {
+    return !(await isLegacyRequest(await toWebRequest(req, req.body)));
+  }
+
+  /** Serve one request on the MCP endpoint. */
   async handleRequest(
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    // `req.body` is already parsed by the router's express.json(), so it is handed over
-    // explicitly: the Node stream is drained by then and cannot be read a second time.
-    const classifiable = await toWebRequest(req, req.body);
-    if (await isLegacyRequest(classifiable)) {
-      await this.legacyNodeHandler(req, res, req.body);
+    if (await this.isModernRequest(req)) {
+      await this.modernNodeHandler(req, res, req.body);
       return;
     }
-    await this.modernNodeHandler(req, res, req.body);
+    await this.handleLegacyRequest(req, res);
   }
 
-  /** Tears down the modern leg's in-flight exchanges. Called when the plugin unloads. */
+  /**
+   * The 2025-era leg: a client opens with `initialize` and is handed an `Mcp-Session-Id`
+   * to send back on every later request, exactly as it was before the 2026-07-28
+   * migration. Requests naming a session that has since gone away are answered 404 so the
+   * client knows to hand-shake again.
+   */
+  private async handleLegacyRequest(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<void> {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+    if (!sessionId) {
+      const { server, toolHandles } = this.buildServer();
+      const transport = new NodeStreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          this.legacySessions.set(id, { server, transport, toolHandles });
+        },
+        onsessionclosed: (id) => {
+          this.legacySessions.delete(id);
+        },
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) this.legacySessions.delete(transport.sessionId);
+      };
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    const session = this.legacySessions.get(sessionId);
+    if (!session) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+    await session.transport.handleRequest(req, res, req.body);
+  }
+
+  /**
+   * Tears down the modern leg's in-flight exchanges and every open legacy session.
+   * Called when the plugin unloads.
+   */
   public close(): void {
-    void this.modernHandler.close().catch((e: unknown) => {
-      if (this.settings.enableVerboseLogging) {
-        console.debug(`[MCP] shutdown failed: ${e instanceof Error ? e.message : "unknown error"}`);
+    const closing: Promise<unknown>[] = [this.modernHandler.close()];
+    for (const session of [...this.legacySessions.values()]) {
+      closing.push(session.transport.close());
+    }
+    this.legacySessions.clear();
+    void Promise.allSettled(closing).then((results) => {
+      if (!this.settings.enableVerboseLogging) return;
+      for (const result of results) {
+        if (result.status === "rejected") {
+          const reason: unknown = result.reason;
+          console.debug(
+            `[MCP] shutdown failed: ${reason instanceof Error ? reason.message : "unknown error"}`,
+          );
+        }
       }
     });
   }

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -88,11 +88,11 @@ interface ResourceSpec {
 }
 
 /**
- * A live 2025-era session: one client's `initialize` handshake, the server instance
+ * A live sessionful-leg session: one client's `initialize` handshake, the server instance
  * pinned to it, and the handles needed to add or drop tools on that instance while it
- * is connected. Modern requests never produce one of these.
+ * is connected. The sessionless leg never produces one of these.
  */
-interface LegacySession {
+interface Session {
   server: McpServer;
   transport: NodeStreamableHTTPServerTransport;
   toolHandles: Map<string, RegisteredTool>;
@@ -106,39 +106,41 @@ export class McpHandler {
   private readonly toolSpecs: Map<string, ToolSpec> = new Map();
   private readonly resourceSpecs: ResourceSpec[] = [];
 
-  // The modern (2026-07-28) leg. `legacy: "reject"` keeps it strictly modern: every
-  // request is answered on its own, with no session id and no cross-request state, and
-  // 2025-era traffic is handed to the separate legacy leg below by `handleRequest`.
-  private readonly modernHandler: McpHttpHandler;
-  private readonly modernNodeHandler: NodeMcpRequestHandler;
+  // The sessionless leg, serving protocol revision 2026-07-28. `legacy: "reject"` keeps
+  // it strictly sessionless: every request is answered on its own, with no session id
+  // and no cross-request state. `handleRequest` routes `initialize`-based traffic to the
+  // separate sessionful leg below.
+  private readonly sessionlessHandler: McpHttpHandler;
+  private readonly sessionlessNodeHandler: NodeMcpRequestHandler;
 
-  // The legacy (2024-10-07 … 2025-11-25) leg, kept deliberately separate from the modern
-  // one. It stays *sessionful*, because that is what those revisions are: a client opens
+  // The sessionful leg, serving protocol revisions 2024-10-07 through 2025-11-25, kept
+  // deliberately separate from the sessionless one. Those revisions are sessionful by
+  // definition: a client opens
   // with `initialize`, the server answers with an `Mcp-Session-Id`, and the capabilities
   // it advertises — including `tools.listChanged` — promise a live notification channel
   // for the rest of the session. Serving those clients statelessly would make that
   // promise a lie and leave a tool an extension registers invisible until the client
-  // happened to re-poll. The session map therefore lives here and only here; the modern
-  // leg neither issues nor reads `Mcp-Session-Id`.
-  private readonly legacySessions: Map<string, LegacySession> = new Map();
+  // happened to re-poll. The session map therefore lives here and only here; the
+  // sessionless leg neither issues nor reads `Mcp-Session-Id`.
+  private readonly sessions: Map<string, Session> = new Map();
 
   constructor(
     private readonly ops: VaultOperations,
     private readonly settings: LocalRestApiSettings,
   ) {
     const onerror = (error: Error) => this.logHandlerError(error);
-    this.modernHandler = createMcpHandler(() => this.buildServer().server, {
+    this.sessionlessHandler = createMcpHandler(() => this.buildServer().server, {
       legacy: "reject",
       onerror,
     });
-    this.modernNodeHandler = toNodeHandler(this.modernHandler, { onerror });
+    this.sessionlessNodeHandler = toNodeHandler(this.sessionlessHandler, { onerror });
     this.registerResources();
     this.registerTools();
   }
 
-  // Build a fresh McpServer from the current specs. The modern leg discards the tool
+  // Build a fresh McpServer from the current specs. The sessionless leg discards the tool
   // handles (it builds one server per request, so nothing outlives the exchange); the
-  // legacy leg keeps them, because its server stays connected for a whole session and
+  // sessionful leg keeps them, because its server stays connected for a whole session and
   // has to learn about tools registered after the handshake.
   private buildServer(): { server: McpServer; toolHandles: Map<string, RegisteredTool> } {
     const server = new McpServer(SERVER_INFO, {
@@ -201,18 +203,18 @@ export class McpHandler {
       },
     };
     this.toolSpecs.set(spec.name, spec);
-    // Modern clients learn about the change through a `subscriptions/listen` stream;
-    // legacy sessions are live server instances, so the tool is registered on each of
+    // Sessionless clients learn about the change through a `subscriptions/listen` stream;
+    // sessionful sessions are live server instances, so the tool is registered on each of
     // them, which is what emits `notifications/tools/list_changed` on their stream.
-    this.modernHandler.notify.toolsChanged();
-    for (const session of this.legacySessions.values()) {
+    this.sessionlessHandler.notify.toolsChanged();
+    for (const session of this.sessions.values()) {
       session.toolHandles.set(spec.name, this.registerToolOn(session.server, spec));
     }
     return {
       remove: () => {
         if (!this.toolSpecs.delete(spec.name)) return;
-        this.modernHandler.notify.toolsChanged();
-        for (const session of this.legacySessions.values()) {
+        this.sessionlessHandler.notify.toolsChanged();
+        for (const session of this.sessions.values()) {
           session.toolHandles.get(spec.name)?.remove();
           session.toolHandles.delete(spec.name);
         }
@@ -239,19 +241,20 @@ export class McpHandler {
   }
 
   /**
-   * Whether a request belongs to the modern (2026-07-28) leg.
+   * Whether a request belongs to the sessionless (2026-07-28) leg.
    *
    * Classification is the SDK's own — `isLegacyRequest` runs exactly the code
    * `createMcpHandler` runs — so nothing that branches on this can disagree with the
    * entry about who owns a request. Anything carrying the 2026-07-28 `_meta` envelope
-   * claim is modern, including a claim naming a revision this server does not serve or a
-   * malformed one: the modern leg owns those error answers (`-32022` / `-32602`).
-   * Everything else — `initialize` handshakes, session GET/DELETE — is 2025-era traffic.
+   * claim is sessionless, including a claim naming a revision this server does not serve
+   * or a malformed one: the sessionless leg owns those error answers (`-32022` / `-32602`).
+   * Everything else — `initialize` handshakes, session GET/DELETE — belongs to the
+   * sessionful leg.
    *
    * `req.body` is passed explicitly because the router's `express.json()` has already
    * drained the Node stream, which cannot be read a second time.
    */
-  public async isModernRequest(req: express.Request): Promise<boolean> {
+  public async isSessionlessRequest(req: express.Request): Promise<boolean> {
     return !(await isLegacyRequest(await toWebRequest(req, req.body)));
   }
 
@@ -260,20 +263,20 @@ export class McpHandler {
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    if (await this.isModernRequest(req)) {
-      await this.modernNodeHandler(req, res, req.body);
+    if (await this.isSessionlessRequest(req)) {
+      await this.sessionlessNodeHandler(req, res, req.body);
       return;
     }
-    await this.handleLegacyRequest(req, res);
+    await this.handleSessionfulRequest(req, res);
   }
 
   /**
-   * The 2025-era leg: a client opens with `initialize` and is handed an `Mcp-Session-Id`
-   * to send back on every later request, exactly as it was before the 2026-07-28
-   * migration. Requests naming a session that has since gone away are answered 404 so the
+   * The sessionful leg, for protocol revisions 2024-10-07 through 2025-11-25: a client
+   * opens with `initialize` and is handed an `Mcp-Session-Id` to send back on every later
+   * request. Requests naming a session that has since gone away are answered 404 so the
    * client knows to hand-shake again.
    */
-  private async handleLegacyRequest(
+  private async handleSessionfulRequest(
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
@@ -284,21 +287,21 @@ export class McpHandler {
       const transport = new NodeStreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
-          this.legacySessions.set(id, { server, transport, toolHandles });
+          this.sessions.set(id, { server, transport, toolHandles });
         },
         onsessionclosed: (id) => {
-          this.legacySessions.delete(id);
+          this.sessions.delete(id);
         },
       });
       transport.onclose = () => {
-        if (transport.sessionId) this.legacySessions.delete(transport.sessionId);
+        if (transport.sessionId) this.sessions.delete(transport.sessionId);
       };
       await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
       return;
     }
 
-    const session = this.legacySessions.get(sessionId);
+    const session = this.sessions.get(sessionId);
     if (!session) {
       res.status(404).json({ error: "Session not found" });
       return;
@@ -307,15 +310,15 @@ export class McpHandler {
   }
 
   /**
-   * Tears down the modern leg's in-flight exchanges and every open legacy session.
+   * Tears down the sessionless leg's in-flight exchanges and every open session.
    * Called when the plugin unloads.
    */
   public close(): void {
-    const closing: Promise<unknown>[] = [this.modernHandler.close()];
-    for (const session of [...this.legacySessions.values()]) {
+    const closing: Promise<unknown>[] = [this.sessionlessHandler.close()];
+    for (const session of [...this.sessions.values()]) {
       closing.push(session.transport.close());
     }
-    this.legacySessions.clear();
+    this.sessions.clear();
     void Promise.allSettled(closing).then((results) => {
       if (!this.settings.enableVerboseLogging) return;
       for (const result of results) {

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -1,8 +1,15 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { McpServer, createMcpHandler, isLegacyRequest, legacyStatelessFallback } from "@modelcontextprotocol/server";
+import type {
+  CacheHint,
+  CallToolResult,
+  McpHttpHandler,
+  ReadResourceResult,
+  StandardSchemaWithJSON,
+  ToolAnnotations,
+} from "@modelcontextprotocol/server";
+import { toNodeHandler, toWebRequest } from "@modelcontextprotocol/node";
+import type { NodeMcpRequestHandler } from "@modelcontextprotocol/node";
 import { posix } from "path";
-import { randomUUID } from "crypto";
 import { z } from "zod";
 import express from "express";
 import { TFile } from "obsidian";
@@ -12,20 +19,30 @@ import { VaultOperations } from "./vaultOperations";
 import type { InstructionInput, ReadTarget } from "markdown-patch-2";
 import { InstructionInputObjectSchema } from "markdown-patch-2";
 import openapiYaml from "../docs/openapi.yaml";
+import { toStandardSchema } from "./mcpSchema";
 import { LocalRestApiSettings } from "./types";
 
-// Minimal structural type for McpServer — typed as a plain interface rather than the SDK's
-// McpServer class to avoid TypeScript heap OOM from evaluating ToolCallback<ZodRawShape>.
-interface MinimalMcpServer {
-  tool(name: string, description: string, schema: unknown, annotations: ToolAnnotations, callback: (args: unknown) => Promise<CallToolResult>): { remove: () => void };
-  connect(transport: StreamableHTTPServerTransport): Promise<void>;
-  resource(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void;
-}
+const SERVER_INFO = { name: "obsidian-local-rest-api", version: "1.0.0" };
+
+// Freshness hints stamped onto every cacheable 2026-07-28 result. The vault is local and
+// changes under the client's feet, so nothing is advertised as `public` — a shared proxy
+// must never hand one vault's listing to another client — and the lifetimes are short
+// enough that a stale answer is measured in seconds. `server/discover` is the exception:
+// the tool/resource capability set only changes when a plugin registers a tool.
+const CACHE_HINTS = {
+  "server/discover": { ttlMs: 300_000, cacheScope: "private" },
+  "tools/list": { ttlMs: 60_000, cacheScope: "private" },
+  "resources/list": { ttlMs: 60_000, cacheScope: "private" },
+  "resources/templates/list": { ttlMs: 60_000, cacheScope: "private" },
+  "resources/read": { ttlMs: 60_000, cacheScope: "private" },
+} as const satisfies Record<string, CacheHint>;
 
 interface ToolSpec {
   name: string;
   description: string;
-  schema: unknown;
+  // Converted from the registered zod shape once, not per request: a request builds a
+  // whole server from these specs, and the shape never changes after registration.
+  inputSchema: StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>>;
   annotations: ToolAnnotations;
   callback: (args: unknown) => Promise<CallToolResult>;
 }
@@ -64,60 +81,86 @@ const HEADING_TARGET_STRING_HINT =
 interface ResourceSpec {
   name: string;
   uri: string;
-  meta: unknown;
-  handler: (uri: URL) => Promise<unknown>;
-}
-
-interface SessionEntry {
-  server: MinimalMcpServer;
-  transport: StreamableHTTPServerTransport;
-  toolHandles: Map<string, { remove: () => void }>;
+  meta: { mimeType?: string; description?: string };
+  handler: (uri: URL) => Promise<ReadResourceResult>;
 }
 
 export class McpHandler {
-  private readonly sessions: Map<string, SessionEntry> = new Map();
+  // The tool and resource registries are this handler's application state: the 2026-07-28
+  // revision has no protocol-level session to hang anything off, so everything a request
+  // needs must be reachable from the handler itself. `buildServer()` replays them onto a
+  // fresh server for every request.
   private readonly toolSpecs: Map<string, ToolSpec> = new Map();
   private readonly resourceSpecs: ResourceSpec[] = [];
+
+  // The modern (2026-07-28) leg. `legacy: "reject"` keeps it strictly modern: every
+  // request is answered on its own, with no session id and no cross-request state, and
+  // 2025-era traffic is handed to the separate legacy leg below by `handleRequest`.
+  private readonly modernHandler: McpHttpHandler;
+  private readonly modernNodeHandler: NodeMcpRequestHandler;
+  // The legacy (2024-10-07 … 2025-11-25) leg, kept deliberately separate from the modern
+  // one so that older clients — which still open with an `initialize` handshake — keep
+  // working unchanged. It is the SDK's own stateless 2025-era serving, so it too holds no
+  // per-session state; the `Mcp-Session-Id` routing this handler used to do is gone.
+  private readonly legacyNodeHandler: NodeMcpRequestHandler;
 
   constructor(
     private readonly ops: VaultOperations,
     private readonly settings: LocalRestApiSettings,
   ) {
+    const factory = () => this.buildServer();
+    const onerror = (error: Error) => this.logHandlerError(error);
+    this.modernHandler = createMcpHandler(factory, { legacy: "reject", onerror });
+    this.modernNodeHandler = toNodeHandler(this.modernHandler, { onerror });
+    this.legacyNodeHandler = toNodeHandler(
+      { fetch: legacyStatelessFallback(factory, onerror) },
+      { onerror },
+    );
     this.registerResources();
     this.registerTools();
   }
 
-  // Build a fresh McpServer for a single session/transport. Each transport MUST own
-  // its own server: the SDK's Server.connect() binds a single _transport, so sharing
-  // one server across multiple connected transports routes every response to the
-  // most-recently-connected transport, hanging all older sessions.
-  private buildServer(): { server: MinimalMcpServer; toolHandles: Map<string, { remove: () => void }> } {
-    const server: MinimalMcpServer = new McpServer({
-      name: "obsidian-local-rest-api",
-      version: "1.0.0",
+  // Build a fresh McpServer for a single request. Both legs are per-request by
+  // construction, so a server instance is never shared between two exchanges.
+  private buildServer(): McpServer {
+    const server = new McpServer(SERVER_INFO, {
+      capabilities: { tools: {}, resources: {} },
+      cacheHints: CACHE_HINTS,
     });
-    const toolHandles = new Map<string, { remove: () => void }>();
     for (const spec of this.resourceSpecs) {
-      server.resource(spec.name, spec.uri, spec.meta, spec.handler);
+      server.registerResource(spec.name, spec.uri, spec.meta, spec.handler);
     }
     for (const spec of this.toolSpecs.values()) {
-      toolHandles.set(spec.name, server.tool(spec.name, spec.description, spec.schema, spec.annotations, spec.callback));
+      server.registerTool(
+        spec.name,
+        {
+          description: spec.description,
+          inputSchema: spec.inputSchema,
+          annotations: spec.annotations,
+        },
+        spec.callback,
+      );
     }
-    return { server, toolHandles };
+    return server;
   }
 
-  private addResourceSpec(name: string, uri: string, meta: unknown, handler: (uri: URL) => Promise<unknown>): void {
+  private logHandlerError(error: Error): void {
+    if (this.settings.enableVerboseLogging) {
+      console.debug(`[MCP] request rejected: ${error.message}`);
+    }
+  }
+
+  private addResourceSpec(name: string, uri: string, meta: { mimeType?: string; description?: string }, handler: (uri: URL) => Promise<ReadResourceResult>): void {
     this.resourceSpecs.push({ name, uri, meta, handler });
   }
 
-  // Args is inferred from the callback's own parameter annotation; the schema is kept
-  // opaque rather than tied to Args via z.objectOutputType to avoid the same SDK type
-  // evaluation blowup described on MinimalMcpServer above.
+  // Args is inferred from the callback's own parameter annotation; the zod shape is
+  // adapted to the SDK's Standard Schema here, at registration time.
   private tool<Args>(name: string, description: string, schema: Record<string, z.ZodTypeAny>, annotations: ToolAnnotations, callback: (args: Args) => Promise<CallToolResult>): { remove: () => void } {
     const spec: ToolSpec = {
       name,
       description,
-      schema,
+      inputSchema: toStandardSchema(schema),
       annotations,
       callback: async (args: unknown) => {
         try {
@@ -135,18 +178,11 @@ export class McpHandler {
       },
     };
     this.toolSpecs.set(spec.name, spec);
-    for (const session of this.sessions.values()) {
-      session.toolHandles.set(spec.name, session.server.tool(spec.name, spec.description, spec.schema, spec.annotations, spec.callback));
-    }
+    this.modernHandler.notify.toolsChanged();
     return {
       remove: () => {
-        this.toolSpecs.delete(spec.name);
-        for (const session of this.sessions.values()) {
-          const handle = session.toolHandles.get(spec.name);
-          if (handle) {
-            handle.remove();
-            session.toolHandles.delete(spec.name);
-          }
+        if (this.toolSpecs.delete(spec.name)) {
+          this.modernHandler.notify.toolsChanged();
         }
       },
     };
@@ -170,34 +206,36 @@ export class McpHandler {
     return () => registered.remove();
   }
 
+  /**
+   * Serve one request on the MCP endpoint.
+   *
+   * Classification is the SDK's own — `isLegacyRequest` runs exactly the code
+   * `createMcpHandler` runs — so the two legs can never disagree about who owns a
+   * request. Anything carrying the 2026-07-28 `_meta` envelope claim (including a claim
+   * naming a revision we do not serve, or a malformed one) belongs to the modern leg,
+   * which owns those error answers; everything else is 2025-era traffic.
+   */
   async handleRequest(
     req: express.Request,
     res: express.Response,
   ): Promise<void> {
-    const sessionId = req.headers["mcp-session-id"] as string | undefined;
-
-    if (!sessionId) {
-      const { server, toolHandles } = this.buildServer();
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        onsessioninitialized: (id) => {
-          this.sessions.set(id, { server, transport, toolHandles });
-        },
-      });
-      transport.onclose = () => {
-        if (transport.sessionId) this.sessions.delete(transport.sessionId);
-      };
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+    // `req.body` is already parsed by the router's express.json(), so it is handed over
+    // explicitly: the Node stream is drained by then and cannot be read a second time.
+    const classifiable = await toWebRequest(req, req.body);
+    if (await isLegacyRequest(classifiable)) {
+      await this.legacyNodeHandler(req, res, req.body);
       return;
     }
+    await this.modernNodeHandler(req, res, req.body);
+  }
 
-    const session = this.sessions.get(sessionId);
-    if (!session) {
-      res.status(404).json({ error: "Session not found" });
-      return;
-    }
-    await session.transport.handleRequest(req, res, req.body);
+  /** Tears down the modern leg's in-flight exchanges. Called when the plugin unloads. */
+  public close(): void {
+    void this.modernHandler.close().catch((e: unknown) => {
+      if (this.settings.enableVerboseLogging) {
+        console.debug(`[MCP] shutdown failed: ${e instanceof Error ? e.message : "unknown error"}`);
+      }
+    });
   }
 
   private text(data: unknown) {

--- a/src/mcpLegacyClient.test.ts
+++ b/src/mcpLegacyClient.test.ts
@@ -1,0 +1,125 @@
+import http from "http";
+import express from "express";
+
+// The real VaultOperations is never instantiated — see mcpHandler.test.ts for why it is
+// kept out of the ts-jest compile.
+jest.mock("./vaultOperations", () => ({ VaultOperations: jest.fn() }));
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+
+import { McpHandler } from "./mcpHandler";
+import { DEFAULT_SETTINGS } from "./constants";
+
+// End-to-end interoperability with a real pre-2026 MCP client, driven by the v1 SDK — the
+// same client the integration suite uses, and the shape every currently-shipping MCP host
+// speaks. The 2026-07-28 migration must not change anything this client observes, so the
+// whole legacy session lifecycle is exercised here: handshake, session id, tool calls, and
+// the `tools/list_changed` notification an extension registering a tool has to produce.
+
+jest.setTimeout(20000);
+
+async function waitFor(condition: () => boolean, what: string): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(`Timed out waiting for ${what}`);
+}
+
+describe("legacy MCP client interoperability", () => {
+  let mcp: McpHandler;
+  let server: http.Server;
+  let client: Client;
+  let transport: StreamableHTTPClientTransport;
+  // The client opens its standalone notification stream lazily, with a GET. A
+  // notification emitted before that stream exists has nowhere to go, so the test waits
+  // for the GET to land rather than sleeping and hoping.
+  let notificationStreamOpen = false;
+
+  beforeEach(async () => {
+    const ops = {
+      app: { vault: { getAbstractFileByPath: jest.fn() }, workspace: { getActiveFile: jest.fn() } },
+      getAllTags: jest.fn().mockReturnValue([{ name: "todo", count: 1 }]),
+    };
+    // @ts-ignore: partial VaultOperations stand-in
+    mcp = new McpHandler(ops, DEFAULT_SETTINGS);
+
+    const app = express();
+    app.use(express.json());
+    app.all("/mcp/", (req, res, next) => {
+      if (req.method === "GET") notificationStreamOpen = true;
+      mcp.handleRequest(req, res).catch(next);
+    });
+    server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const { port } = server.address() as { port: number };
+    client = new Client({ name: "v1-legacy-client", version: "1.0.0" });
+    transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp/`));
+  });
+
+  afterEach(async () => {
+    await client.close().catch(() => undefined);
+    mcp.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    notificationStreamOpen = false;
+  });
+
+  test("connects, is given a session, and calls tools", async () => {
+    await client.connect(transport);
+
+    expect(transport.sessionId).toEqual(expect.any(String));
+    expect(client.getServerCapabilities()?.tools?.listChanged).toBe(true);
+    expect((await client.listTools()).tools).toHaveLength(16);
+
+    const result = await client.callTool({ name: "tag_list", arguments: {} });
+    expect(JSON.parse((result.content as { text: string }[])[0].text)).toEqual({
+      tags: [{ name: "todo", count: 1 }],
+    });
+  });
+
+  test("is notified when an extension registers a tool, and can call it", async () => {
+    let listChanged = false;
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      listChanged = true;
+    });
+    await client.connect(transport);
+    await waitFor(() => notificationStreamOpen, "the client's notification stream");
+
+    mcp.registerTool("extension_tool", "From an extension", {}, async () => "hi");
+
+    await waitFor(() => listChanged, "notifications/tools/list_changed");
+    expect((await client.listTools()).tools.map((t) => t.name)).toContain("extension_tool");
+    expect(await client.callTool({ name: "extension_tool", arguments: {} })).toMatchObject({
+      content: [{ type: "text", text: "hi" }],
+    });
+  });
+
+  test("is notified when an extension removes a tool", async () => {
+    const cleanup = mcp.registerTool("extension_tool", "From an extension", {}, async () => "hi");
+    let listChanged = false;
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      listChanged = true;
+    });
+    await client.connect(transport);
+    await waitFor(() => notificationStreamOpen, "the client's notification stream");
+
+    cleanup();
+
+    await waitFor(() => listChanged, "notifications/tools/list_changed");
+    expect((await client.listTools()).tools.map((t) => t.name)).not.toContain("extension_tool");
+  });
+
+  test("terminating the session frees it server-side", async () => {
+    await client.connect(transport);
+    const sessionId = transport.sessionId;
+    await transport.terminateSession();
+
+    const sessions = (mcp as unknown as { legacySessions: Map<string, unknown> }).legacySessions;
+    expect(sessionId).toEqual(expect.any(String));
+    expect(sessions.size).toBe(0);
+  });
+});

--- a/src/mcpSchema.test.ts
+++ b/src/mcpSchema.test.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+import { toStandardSchema } from "./mcpSchema";
+
+describe("toStandardSchema", () => {
+  test("advertises the shape as JSON Schema for tools/list", () => {
+    const schema = toStandardSchema({
+      path: z.string().describe("File path relative to vault root"),
+      newLeaf: z.boolean().optional(),
+    });
+
+    const json = schema["~standard"].jsonSchema.input({ target: "draft-2020-12" });
+
+    expect(json).toMatchObject({
+      type: "object",
+      properties: {
+        path: { type: "string", description: "File path relative to vault root" },
+        newLeaf: { type: "boolean" },
+      },
+      required: ["path"],
+    });
+  });
+
+  test("keeps anyOf branches for union parameters", () => {
+    const schema = toStandardSchema({
+      target: z.union([z.array(z.string()), z.string()]).optional(),
+    });
+
+    const json = schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as {
+      properties: { target: { anyOf: unknown[] } };
+    };
+
+    expect(json.properties.target.anyOf).toHaveLength(2);
+  });
+
+  test("validates arguments with the zod schema the tool was registered with", async () => {
+    const schema = toStandardSchema({ path: z.string() });
+
+    const accepted = await schema["~standard"].validate({ path: "note.md" });
+    expect(accepted).toEqual({ value: { path: "note.md" } });
+
+    const rejected = await schema["~standard"].validate({ path: 42 });
+    expect(rejected.issues).toBeDefined();
+  });
+
+  test("reports zod as the vendor so the SDK keeps its zod-aware error formatting", () => {
+    expect(toStandardSchema({})["~standard"].vendor).toBe("zod");
+  });
+});

--- a/src/mcpSchema.ts
+++ b/src/mcpSchema.ts
@@ -19,9 +19,11 @@ const toJsonSchema = zodToJsonSchema as unknown as (
  * and cannot be moved without breaking every extension author.
  *
  * This adapter closes that gap: validation is delegated to zod 3's own Standard Schema
- * implementation, and the JSON Schema is produced by `zod-to-json-schema` with the very
- * options the v1 SDK used, so the shapes advertised in `tools/list` are byte-for-byte what
- * MCP clients received before the 2026-07-28 migration.
+ * implementation, and the JSON Schema is produced by `zod-to-json-schema` with the same
+ * options SDK v1 used, so `tools/list` advertises identical shapes under either SDK.
+ *
+ * Delete this file once the project's own schemas are zod 4, which implements
+ * `~standard.jsonSchema` natively.
  */
 export function toStandardSchema(
   shape: Record<string, z.ZodTypeAny>,

--- a/src/mcpSchema.ts
+++ b/src/mcpSchema.ts
@@ -1,0 +1,49 @@
+import type { StandardSchemaWithJSON } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+// zod-to-json-schema's generic signature is resolved eagerly against the converted
+// schema and trips TypeScript's instantiation-depth limit on this project's larger tool
+// shapes. Only the JSON Schema document is needed here, so the call is made through a
+// narrowed alias.
+const toJsonSchema = zodToJsonSchema as unknown as (
+  schema: z.ZodTypeAny,
+  options?: { strictUnions?: boolean; pipeStrategy?: "input" | "output" },
+) => Record<string, unknown>;
+
+/**
+ * The MCP TypeScript SDK v2 registers tools with a Standard Schema that also knows how to
+ * describe itself as JSON Schema (`~standard.jsonSchema`). Zod only grew that member in
+ * v4, and the SDK refuses a bare zod 3 schema outright, but this plugin's tool schemas —
+ * and the `addMcpTool` extension API that third-party plugins compile against — are zod 3
+ * and cannot be moved without breaking every extension author.
+ *
+ * This adapter closes that gap: validation is delegated to zod 3's own Standard Schema
+ * implementation, and the JSON Schema is produced by `zod-to-json-schema` with the very
+ * options the v1 SDK used, so the shapes advertised in `tools/list` are byte-for-byte what
+ * MCP clients received before the 2026-07-28 migration.
+ */
+export function toStandardSchema(
+  shape: Record<string, z.ZodTypeAny>,
+): StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>> {
+  // Annotated as the base type rather than the inferred ZodObject: the SDK's Standard
+  // Schema surface only needs the base.
+  const schema: z.ZodTypeAny = z.object(shape);
+  const standard = schema["~standard"];
+  const jsonSchema = toJsonSchema(schema, {
+    strictUnions: true,
+    pipeStrategy: "input",
+  });
+
+  return {
+    "~standard": {
+      version: 1,
+      vendor: standard.vendor,
+      validate: (value) => standard.validate(value),
+      jsonSchema: {
+        input: () => jsonSchema,
+        output: () => jsonSchema,
+      },
+    },
+  };
+}

--- a/src/mcpSessionfulClient.test.ts
+++ b/src/mcpSessionfulClient.test.ts
@@ -12,10 +12,10 @@ import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/typ
 import { McpHandler } from "./mcpHandler";
 import { DEFAULT_SETTINGS } from "./constants";
 
-// End-to-end interoperability with a real pre-2026 MCP client, driven by the v1 SDK — the
-// same client the integration suite uses, and the shape every currently-shipping MCP host
-// speaks. The 2026-07-28 migration must not change anything this client observes, so the
-// whole legacy session lifecycle is exercised here: handshake, session id, tool calls, and
+// End-to-end interoperability with a sessionful (pre-2026) MCP client, driven by the v1
+// SDK — the same client the integration suite uses. The v1 SDK is a test-only
+// devDependency: no non-test module may import it. The whole sessionful lifecycle such a
+// client observes is exercised here: handshake, session id, tool calls, and
 // the `tools/list_changed` notification an extension registering a tool has to produce.
 
 jest.setTimeout(20000);
@@ -29,7 +29,7 @@ async function waitFor(condition: () => boolean, what: string): Promise<void> {
   throw new Error(`Timed out waiting for ${what}`);
 }
 
-describe("legacy MCP client interoperability", () => {
+describe("sessionful MCP client interoperability", () => {
   let mcp: McpHandler;
   let server: http.Server;
   let client: Client;
@@ -57,7 +57,7 @@ describe("legacy MCP client interoperability", () => {
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
 
     const { port } = server.address() as { port: number };
-    client = new Client({ name: "v1-legacy-client", version: "1.0.0" });
+    client = new Client({ name: "v1-sessionful-client", version: "1.0.0" });
     transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp/`));
   });
 
@@ -118,7 +118,7 @@ describe("legacy MCP client interoperability", () => {
     const sessionId = transport.sessionId;
     await transport.terminateSession();
 
-    const sessions = (mcp as unknown as { legacySessions: Map<string, unknown> }).legacySessions;
+    const sessions = (mcp as unknown as { sessions: Map<string, unknown> }).sessions;
     expect(sessionId).toEqual(expect.any(String));
     expect(sessions.size).toBe(0);
   });

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -36,7 +36,7 @@ export const LOCAL_REST_API_PLUGIN_ID = "obsidian-local-rest-api";
 /**
  * Behavior hints attached to a registered MCP tool.
  *
- * Structurally identical to `ToolAnnotations` from `@modelcontextprotocol/sdk`, but
+ * Structurally identical to `ToolAnnotations` from `@modelcontextprotocol/server`, but
  * declared here so that consuming this package's types does not require the SDK to be
  * installed. The host passes whatever it receives straight through to the SDK.
  */

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -8,7 +8,11 @@ jest.mock("./mcpHandler", () => ({
     handleRequest: jest.fn().mockImplementation((_req: unknown, res: { status: (c: number) => { json: (b: unknown) => void } }) => {
       res.status(200).json({ ok: true });
     }),
+    // Classification is exercised for real in mcpEndpoint.test.ts; here it stands in for
+    // a legacy-shaped request so the router's version filter keeps its plain rejection.
+    isModernRequest: jest.fn().mockResolvedValue(false),
     registerTool: jest.fn().mockReturnValue(jest.fn()),
+    close: jest.fn(),
   })),
 }));
 
@@ -3894,6 +3898,41 @@ describe("requestHandler", () => {
         .set("Authorization", `Bearer ${API_KEY}`)
         .set("MCP-Protocol-Version", "2025-03-26")
         .expect(200);
+    });
+
+    test("POST /mcp/ with an unrecognised version reaches the handler when the request is modern-shaped", async () => {
+      const mcpHandler = handler.mcpHandler as unknown as {
+        isModernRequest: jest.Mock;
+        handleRequest: jest.Mock;
+      };
+      mcpHandler.isModernRequest.mockResolvedValueOnce(true);
+
+      // The router must not answer this itself: only the MCP handler can reply with the
+      // JSON-RPC -32022 that names the revisions it serves.
+      await request(server)
+        .post("/mcp/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("MCP-Protocol-Version", "2026-07-29")
+        .expect(200);
+
+      expect(mcpHandler.handleRequest).toHaveBeenCalled();
+    });
+
+    test("POST /mcp/ with an unrecognised version is rejected by the router when the request is legacy-shaped", async () => {
+      const mcpHandler = handler.mcpHandler as unknown as {
+        isModernRequest: jest.Mock;
+        handleRequest: jest.Mock;
+      };
+      mcpHandler.isModernRequest.mockResolvedValueOnce(false);
+
+      const res = await request(server)
+        .post("/mcp/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("MCP-Protocol-Version", "2026-07-29")
+        .expect(400);
+
+      expect(res.body.error).toMatch(/Unsupported MCP-Protocol-Version/);
+      expect(mcpHandler.handleRequest).not.toHaveBeenCalled();
     });
 
     test("POST /mcp/ with MCP-Protocol-Version 2026-07-28 passes through", async () => {

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -9,8 +9,8 @@ jest.mock("./mcpHandler", () => ({
       res.status(200).json({ ok: true });
     }),
     // Classification is exercised for real in mcpEndpoint.test.ts; here it stands in for
-    // a legacy-shaped request so the router's version filter keeps its plain rejection.
-    isModernRequest: jest.fn().mockResolvedValue(false),
+    // a sessionful-shaped request so the router's version filter applies its plain rejection.
+    isSessionlessRequest: jest.fn().mockResolvedValue(false),
     registerTool: jest.fn().mockReturnValue(jest.fn()),
     close: jest.fn(),
   })),
@@ -3900,12 +3900,12 @@ describe("requestHandler", () => {
         .expect(200);
     });
 
-    test("POST /mcp/ with an unrecognised version reaches the handler when the request is modern-shaped", async () => {
+    test("POST /mcp/ with an unrecognised version reaches the handler when the request is sessionless-shaped", async () => {
       const mcpHandler = handler.mcpHandler as unknown as {
-        isModernRequest: jest.Mock;
+        isSessionlessRequest: jest.Mock;
         handleRequest: jest.Mock;
       };
-      mcpHandler.isModernRequest.mockResolvedValueOnce(true);
+      mcpHandler.isSessionlessRequest.mockResolvedValueOnce(true);
 
       // The router must not answer this itself: only the MCP handler can reply with the
       // JSON-RPC -32022 that names the revisions it serves.
@@ -3918,12 +3918,12 @@ describe("requestHandler", () => {
       expect(mcpHandler.handleRequest).toHaveBeenCalled();
     });
 
-    test("POST /mcp/ with an unrecognised version is rejected by the router when the request is legacy-shaped", async () => {
+    test("POST /mcp/ with an unrecognised version is rejected by the router when the request is sessionful-shaped", async () => {
       const mcpHandler = handler.mcpHandler as unknown as {
-        isModernRequest: jest.Mock;
+        isSessionlessRequest: jest.Mock;
         handleRequest: jest.Mock;
       };
-      mcpHandler.isModernRequest.mockResolvedValueOnce(false);
+      mcpHandler.isSessionlessRequest.mockResolvedValueOnce(false);
 
       const res = await request(server)
         .post("/mcp/")

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -3896,6 +3896,14 @@ describe("requestHandler", () => {
         .expect(200);
     });
 
+    test("POST /mcp/ with MCP-Protocol-Version 2026-07-28 passes through", async () => {
+      await request(server)
+        .post("/mcp/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("MCP-Protocol-Version", "2026-07-28")
+        .expect(200);
+    });
+
     test("POST /mcp/ without MCP-Protocol-Version passes through", async () => {
       await request(server)
         .post("/mcp/")

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -56,7 +56,7 @@ import {
   CERT_NAME,
   ContentTypes,
   ERROR_CODE_MESSAGES,
-  MCP_MODERN_PROTOCOL_VERSION,
+  MCP_SESSIONLESS_PROTOCOL_VERSION,
   MaximumRequestSize,
 } from "./constants";
 import {
@@ -2252,28 +2252,29 @@ export default class RequestHandler {
       next();
     });
     // Body parsing runs before the version filter: deciding what an unrecognised version
-    // header means requires knowing whether the request is modern- or legacy-shaped, and
+    // header means requires knowing whether the request is sessionless- or sessionful-shaped, and
     // that is a property of the body.
     mcpRouter.use(express.json({ limit: MaximumRequestSize }));
     mcpRouter.use((req, res, next) => {
       const version = req.headers["mcp-protocol-version"] as string | undefined;
       if (
         version === undefined ||
-        version === MCP_MODERN_PROTOCOL_VERSION ||
+        version === MCP_SESSIONLESS_PROTOCOL_VERSION ||
         SUPPORTED_PROTOCOL_VERSIONS.includes(version)
       ) {
         next();
         return;
       }
-      // An unrecognised version on a modern-shaped request is the MCP handler's to
-      // answer: it replies with JSON-RPC `-32022` naming the revisions it does serve,
-      // which is how a modern client learns what to fall back to. Answering here with a
-      // bare `{error}` body would strand that client. Legacy-shaped requests keep the
-      // plain rejection they have always had.
+      // An unrecognised version on a sessionless-shaped request (one carrying the
+      // `_meta` envelope) is the MCP handler's to answer: it replies with JSON-RPC
+      // `-32022` naming the revisions it does serve, which is how such a client learns
+      // what to fall back to. Answering here with a bare `{error}` body would strand
+      // that client. A sessionful-shaped request carries nothing the SDK can classify,
+      // so it is rejected here with a plain `{error}` body.
       this.mcpHandler
-        .isModernRequest(req)
-        .then((isModern) => {
-          if (isModern) {
+        .isSessionlessRequest(req)
+        .then((isSessionless) => {
+          if (isSessionless) {
             next();
             return;
           }

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -37,7 +37,7 @@ import type {
   PublicMap,
   ReadTarget,
 } from "markdown-patch-2";
-import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/server";
 
 import {
   CannedResponse,
@@ -56,6 +56,7 @@ import {
   CERT_NAME,
   ContentTypes,
   ERROR_CODE_MESSAGES,
+  MCP_MODERN_PROTOCOL_VERSION,
   MaximumRequestSize,
 } from "./constants";
 import {
@@ -2252,7 +2253,11 @@ export default class RequestHandler {
     });
     mcpRouter.use((req, res, next) => {
       const version = req.headers["mcp-protocol-version"] as string | undefined;
-      if (version !== undefined && !SUPPORTED_PROTOCOL_VERSIONS.includes(version)) {
+      if (
+        version !== undefined &&
+        version !== MCP_MODERN_PROTOCOL_VERSION &&
+        !SUPPORTED_PROTOCOL_VERSIONS.includes(version)
+      ) {
         res.status(400).json({ error: `Unsupported MCP-Protocol-Version: ${version}` });
         return;
       }

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -2251,19 +2251,36 @@ export default class RequestHandler {
       }
       next();
     });
+    // Body parsing runs before the version filter: deciding what an unrecognised version
+    // header means requires knowing whether the request is modern- or legacy-shaped, and
+    // that is a property of the body.
+    mcpRouter.use(express.json({ limit: MaximumRequestSize }));
     mcpRouter.use((req, res, next) => {
       const version = req.headers["mcp-protocol-version"] as string | undefined;
       if (
-        version !== undefined &&
-        version !== MCP_MODERN_PROTOCOL_VERSION &&
-        !SUPPORTED_PROTOCOL_VERSIONS.includes(version)
+        version === undefined ||
+        version === MCP_MODERN_PROTOCOL_VERSION ||
+        SUPPORTED_PROTOCOL_VERSIONS.includes(version)
       ) {
-        res.status(400).json({ error: `Unsupported MCP-Protocol-Version: ${version}` });
+        next();
         return;
       }
-      next();
+      // An unrecognised version on a modern-shaped request is the MCP handler's to
+      // answer: it replies with JSON-RPC `-32022` naming the revisions it does serve,
+      // which is how a modern client learns what to fall back to. Answering here with a
+      // bare `{error}` body would strand that client. Legacy-shaped requests keep the
+      // plain rejection they have always had.
+      this.mcpHandler
+        .isModernRequest(req)
+        .then((isModern) => {
+          if (isModern) {
+            next();
+            return;
+          }
+          res.status(400).json({ error: `Unsupported MCP-Protocol-Version: ${version}` });
+        })
+        .catch(next);
     });
-    mcpRouter.use(express.json({ limit: MaximumRequestSize }));
     mcpRouter.all("/", (req, res, next) => {
       this.mcpHandler.handleRequest(req, res).catch(next);
     });


### PR DESCRIPTION
## Summary

Serve the [July 28, 2026 MCP specification](https://modelcontextprotocol.io/specification/2026-07-28) through the official TypeScript SDK v2 while preserving initialization-based MCP clients.

- add a stateless modern handler with `server/discover`, per-request protocol metadata, required result/cache fields, and modern Streamable HTTP validation
- retain a sessionful legacy Streamable HTTP path, including `Mcp-Session-Id`, GET/DELETE lifecycle operations, and dynamic `tools/list_changed` notifications
- route unsupported modern protocol versions to the SDK so clients receive `-32022` with supported versions
- preserve the public Zod 3 extension API through a Standard Schema bridge
- update README, OpenAPI output, generated public API files, unit tests, mounted-endpoint tests, and integration test coverage

## Validation

- `npm test` (415 tests)
- `npm run typecheck`
- `npx tsc -p tsconfig.integration.json --noEmit`
- `npm run lint`
- `npm run build`
- `npm run build-docs`
- `npm run build-toc`
- `npm run build-types`
- real SDK v1 client coverage for initialization, session reuse, tool calls, dynamic tool notifications, and termination

The live Obsidian integration suite requires a running Obsidian instance and `OBSIDIAN_API_KEY`; that environment was not available locally.
