### PR TITLE
Keep the sample MCP config from overflowing its code block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,7 @@ div.obsidian-local-rest-api-content pre {
   background-color: var(--background-modifier-cover);
   font-family: monospace;
   user-select: all;
+  overflow-x: auto;
 }
 
 div.obsidian-local-rest-api-content p {


### PR DESCRIPTION
Simple edit to styles.css to fix text overflow.

The plain \<pre\> used for the sample MCP client JSON config had no
overflow handling, so long unbroken lines (specifically the
Authorization header line, which includes the full API key) spilled
past the block's background instead of scrolling or wrapping.

Every other pre in this settings page (the standalone copyable
Bearer-token/API-key values) already sets overflow-x: auto for this
same reason; this rule, which is the base style every plain pre in
the settings content falls back to, was the one place that got
missed.

I verified visually that this change fixes the issue.