### PR TITLE
Fixes #330 surrogate pair handling in simpleSearch context slicing

### DIFF
--- a/src/vaultOperations.test.ts
+++ b/src/vaultOperations.test.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "../mocks/obsidian";
+import { App, TFile, _prepareSimpleSearchMock } from "../mocks/obsidian";
 import { VaultOperations } from "./vaultOperations";
 import { LocalRestApiSettings } from "./types";
 
@@ -77,5 +77,72 @@ describe("writes go through the Vault API", () => {
     const { app, ops } = setup("");
     await ops.writeFileContent("image.png", Buffer.from([1, 2, 3]));
     expect(app.vault.adapter._writeBinary?.[0]).toBe("image.png");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// simpleSearch context slicing must not split UTF-16 surrogate pairs.
+//
+// Obsidian's prepareSimpleSearch reports matches as UTF-16 code-unit offsets,
+// and the context window is produced with String.prototype.slice, which also
+// works in code units. When a contextLength boundary lands between the two
+// halves of a surrogate pair (e.g. the emoji 🔌 = U+D83D U+DD0C), the returned
+// context can contain an unpaired surrogate. See
+// https://github.com/coddingtonbear/obsidian-local-rest-api/issues/330.
+// ---------------------------------------------------------------------------
+
+describe("simpleSearch surrogate handling", () => {
+  function searchSetup(content: string, contextLength: number): {
+    ops: VaultOperations;
+    results: () => Promise<{ context: string }[]>;
+  } {
+    const query = "needle";
+    const file = new TFile();
+    file.basename = "note";
+    file.path = "note.md";
+
+    const app = new App();
+    app.vault._markdownFiles = [file];
+    app.vault._cachedRead = content;
+    // "note\n\n" is prepended as the filename prefix, so the first 6 code units
+    // are the prefix; the content starts at offset 6.
+    _prepareSimpleSearchMock.behavior = (query: string) => {
+      const queryLength = query.length;
+      return (text: string) => {
+        const index = text.indexOf(query, 6);
+        if (index === -1) return null;
+        return {
+          score: 1,
+          matches: [[index, index + queryLength]],
+        };
+      };
+    };
+
+    const ops = new VaultOperations(app, {} as LocalRestApiSettings);
+    return {
+      ops,
+      results: async () =>
+        (await ops.simpleSearch(query, contextLength)).flatMap((r) =>
+          r.matches.map((m) => ({ context: m.context })),
+        ),
+    };
+  }
+
+  afterEach(() => {
+    _prepareSimpleSearchMock.behavior = null;
+  });
+
+  test("start boundary splits a surrogate pair (issue #330 repro)", async () => {
+    // 🔌 (U+D83D U+DD0C) precedes the match; a contextLength of 2 slices from
+    // code-unit 1, between the two surrogate halves.
+    const { results } = searchSetup("🔌xneedle", 2);
+    expect(await results()).toEqual([{ context: "🔌xneedle" }]);
+  });
+
+  test("end boundary splits a surrogate pair", async () => {
+    // The match ends at code-unit 7; a contextLength of 1 slices up to code-unit
+    // 8, which sits between the surrogate halves of the trailing 🔌.
+    const { results } = searchSetup("xneedle🔌", 1);
+    expect(await results()).toEqual([{ context: "xneedle🔌" }]);
   });
 });

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -604,7 +604,7 @@ export class VaultOperations {
                 source: "content",
               },
               context: cachedContents.slice(
-                ...this.adjustContextBounds(
+                ...this.widenToCodePointBoundaries(
                   cachedContents,
                   Math.max(match[0] - positionOffset - contextLength, 0),
                   match[1] - positionOffset + contextLength,
@@ -658,29 +658,52 @@ export class VaultOperations {
     return Boolean(value);
   }
 
-  // String.slice works on UTF-16 code units, so a context boundary can land
-  // between the two halves of a surrogate pair (e.g. an emoji). Adjust the
-  // bounds so the returned context never contains an unpaired surrogate.
-  private adjustContextBounds(
-    cachedContents: string,
+  /**
+   * Widen a `[start, end)` UTF-16 code-unit range in `text` so that neither
+   * end falls between the two halves of a surrogate pair. `String.prototype.slice`
+   * works in code units, so a window computed from `contextLength` can bisect a
+   * non-BMP character such as an emoji and hand back an unpaired surrogate
+   * (e.g. `\udd0c`), which cannot be encoded as UTF-8. The range is only ever
+   * grown, by at most one code unit per side: a `start` on a low surrogate
+   * moves back to include its high surrogate, and an `end` just past a high
+   * surrogate moves forward to include its low surrogate. Out-of-range bounds
+   * and boundaries already on a whole code point are returned unchanged.
+   * Lone surrogates already present in `text` are not repaired.
+   *
+   * This is deliberately not `String.prototype.toWellFormed()` (ES2024). That
+   * method operates on an already-sliced string, so the missing half of the
+   * pair is gone by the time it runs and the character cannot be recovered;
+   * it substitutes U+FFFD (`\ufffd`) for each lone surrogate instead, which
+   * would put a visible replacement character into user-facing search context
+   * where the original emoji belongs. Widening the range before slicing keeps
+   * the whole character.
+   *
+   * @param text The string the range indexes into.
+   * @param start Inclusive start offset, in UTF-16 code units.
+   * @param end Exclusive end offset, in UTF-16 code units.
+   * @returns The `[start, end)` pair, widened where necessary, suitable for
+   *   spreading into `text.slice`.
+   */
+  private widenToCodePointBoundaries(
+    text: string,
     start: number,
     end: number,
   ): [number, number] {
-    let adjustedStart = start;
-    if (adjustedStart > 0 && adjustedStart < cachedContents.length) {
-      const codeUnit = cachedContents.charCodeAt(adjustedStart);
+    let widenedStart = start;
+    if (widenedStart > 0 && widenedStart < text.length) {
+      const codeUnit = text.charCodeAt(widenedStart);
       if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-        adjustedStart -= 1;
+        widenedStart -= 1;
       }
     }
-    let adjustedEnd = end;
-    if (adjustedEnd > 0 && adjustedEnd < cachedContents.length) {
-      const codeUnit = cachedContents.charCodeAt(adjustedEnd - 1);
+    let widenedEnd = end;
+    if (widenedEnd > 0 && widenedEnd < text.length) {
+      const codeUnit = text.charCodeAt(widenedEnd - 1);
       if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-        adjustedEnd += 1;
+        widenedEnd += 1;
       }
     }
-    return [adjustedStart, adjustedEnd];
+    return [widenedStart, widenedEnd];
   }
 
   getAllTags(): Array<{ name: string; count: number }> {

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -604,8 +604,11 @@ export class VaultOperations {
                 source: "content",
               },
               context: cachedContents.slice(
-                Math.max(match[0] - positionOffset - contextLength, 0),
-                match[1] - positionOffset + contextLength,
+                ...this.adjustContextBounds(
+                  cachedContents,
+                  Math.max(match[0] - positionOffset - contextLength, 0),
+                  match[1] - positionOffset + contextLength,
+                ),
               ),
             });
           }
@@ -653,6 +656,31 @@ export class VaultOperations {
     if (Array.isArray(value)) return value.length > 0;
     if (typeof value === "object") return Object.keys(value).length > 0;
     return Boolean(value);
+  }
+
+  // String.slice works on UTF-16 code units, so a context boundary can land
+  // between the two halves of a surrogate pair (e.g. an emoji). Adjust the
+  // bounds so the returned context never contains an unpaired surrogate.
+  private adjustContextBounds(
+    cachedContents: string,
+    start: number,
+    end: number,
+  ): [number, number] {
+    let adjustedStart = start;
+    if (adjustedStart > 0 && adjustedStart < cachedContents.length) {
+      const codeUnit = cachedContents.charCodeAt(adjustedStart);
+      if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+        adjustedStart -= 1;
+      }
+    }
+    let adjustedEnd = end;
+    if (adjustedEnd > 0 && adjustedEnd < cachedContents.length) {
+      const codeUnit = cachedContents.charCodeAt(adjustedEnd - 1);
+      if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+        adjustedEnd += 1;
+      }
+    }
+    return [adjustedStart, adjustedEnd];
   }
 
   getAllTags(): Array<{ name: string; count: number }> {


### PR DESCRIPTION
This is a fix for #330: surrogate pair handling in simpleSearch context slicing

Co-Authored-By: DeepSeek V4 <noreply@deepseek.com>