### PR TITLE
Expose response headers to browser clients via CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Give your scripts, browser extensions, and AI agents a direct line into your Obs
     + [Cursor](#cursor)
     + [Other clients](#other-clients)
 - [API overview](#api-overview)
+  * [Browser clients and response headers](#browser-clients-and-response-headers)
 - [Patching notes](#patching-notes)
   * [Raw-content mode](#raw-content-mode)
 - [Targeting specific sections](#targeting-specific-sections)
@@ -171,6 +172,12 @@ Any MCP client that supports the Streamable HTTP transport can connect to `https
 | `/mcp/` | GET POST | MCP (Model Context Protocol) server — connect AI agents directly to your vault |
 
 For full request/response details, see the [interactive docs](https://coddingtonbear.github.io/obsidian-local-rest-api/).
+
+### Browser clients and response headers
+
+Several endpoints answer in a response header rather than in the body: `Content-Location` tells you where a write actually landed, `Markdown-Patch-Warnings` reports what a `PATCH` had to work around, `Deprecation` warns that a format is sunsetting, and `Mcp-Session-Id` carries the session for a sessionful MCP connection.
+
+Browsers hide response headers from JavaScript unless the server opts them in, so the API sends `Access-Control-Expose-Headers: *` and all of them are readable with `response.headers.get(...)`. Safari honours the wildcard from 15.4 onward; older browsers see only the [CORS-safelisted headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header). Requests made with `credentials: "include"` are not supported — the API authenticates with a bearer token and sends `Access-Control-Allow-Origin: *`, which browsers reject for credentialed requests.
 
 ## Patching notes
 

--- a/src/integration/cors.test.ts
+++ b/src/integration/cors.test.ts
@@ -1,0 +1,71 @@
+import { authedFetch, unauthFetch, ensureServerReachable, resetFixture, deleteFixture, BASE_URL } from "./client";
+import { FIXTURE_DOCUMENT, TEST_PATH, HEADING_DELTA } from "./fixtures";
+
+// The unit tests assemble the router under supertest; these drive the real server, which
+// is where the ordering of cors() against the auth and body-parsing middleware actually
+// holds. A browser reads a response header only if Access-Control-Expose-Headers names
+// it, and this API answers several questions in headers rather than in the body.
+
+const ORIGIN = "https://example.com";
+
+beforeAll(async () => {
+  await ensureServerReachable();
+});
+
+describe("CORS exposed response headers", () => {
+  test("GET / exposes every response header", async () => {
+    const res = await unauthFetch("/", { headers: { Origin: ORIGIN } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-expose-headers")).toBe("*");
+  });
+
+  test("the /mcp/ router exposes every response header", async () => {
+    // cors runs ahead of the MCP router's auth middleware, so an unauthenticated request
+    // is enough to observe the directive -- and it avoids needing a valid MCP handshake.
+    // Mcp-Session-Id rides this router, and the MCP SDK's own browser client reads that
+    // header off the response to establish a sessionful connection.
+    const res = await fetch(`${BASE_URL}/mcp/`, { headers: { Origin: ORIGIN } });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("access-control-expose-headers")).toBe("*");
+  });
+
+  test("a preflight still reflects the headers the request asked for", async () => {
+    // The request direction was never broken; pinned so that a change to the response
+    // direction cannot quietly cost us the request direction.
+    const res = await fetch(`${BASE_URL}/`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: ORIGIN,
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "authorization, content-type",
+      },
+    });
+    expect(res.headers.get("access-control-allow-headers")).toBe("authorization, content-type");
+  });
+
+  describe("against a response that really sets a custom header", () => {
+    beforeAll(async () => {
+      await resetFixture(FIXTURE_DOCUMENT, TEST_PATH);
+    });
+
+    afterAll(async () => {
+      await deleteFixture(TEST_PATH);
+    });
+
+    test("a POST that returns Content-Location exposes it to a browser", async () => {
+      // Content-Location is the answer to "where did my write actually land" -- the whole
+      // point of the section-targeting routes. Asserting the header and the directive
+      // together is what proves a browser client can read it, rather than merely that the
+      // directive is set on some other response.
+      const res = await authedFetch(`/vault/${TEST_PATH}/heading/${HEADING_DELTA}`, {
+        method: "POST",
+        headers: { "Content-Type": "text/markdown", Origin: ORIGIN },
+        body: "A line appended by the CORS integration test.",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-location")).toBeTruthy();
+      expect(res.headers.get("access-control-expose-headers")).toBe("*");
+    });
+  });
+});

--- a/src/requestHandler.test.ts
+++ b/src/requestHandler.test.ts
@@ -3844,6 +3844,51 @@ describe("requestHandler", () => {
     });
   });
 
+  describe("cors", () => {
+    // Without `exposedHeaders`, the `cors` package omits Access-Control-Expose-Headers
+    // entirely, and a browser may then read only the seven CORS-safelisted response
+    // headers. Every header this API sets to tell a client something -- Content-Location,
+    // Deprecation, Markdown-Patch-Warnings, Mcp-Session-Id -- is on the wire but
+    // unreadable from JavaScript. These tests pin the directive onto both routers.
+
+    test("GET / exposes every response header to browser clients", async () => {
+      const response = await request(server)
+        .get("/")
+        .set("Origin", "https://example.com")
+        .expect(200);
+
+      expect(response.headers["access-control-expose-headers"]).toEqual("*");
+    });
+
+    test("the /mcp/ router exposes every response header to browser clients", async () => {
+      // Mcp-Session-Id rides this router, and the MCP SDK's own browser client reads it
+      // off the response to complete a sessionful handshake.
+      const response = await request(server)
+        .post("/mcp/")
+        .set("Authorization", `Bearer ${API_KEY}`)
+        .set("Origin", "https://example.com")
+        .expect(200);
+
+      expect(response.headers["access-control-expose-headers"]).toEqual("*");
+    });
+
+    test("a preflight still reflects the headers the request asked for", async () => {
+      // The request direction was never broken -- `cors` reflects
+      // Access-Control-Request-Headers by default. Pinned so a change to the response
+      // direction cannot quietly cost us the request direction.
+      const response = await request(server)
+        .options("/")
+        .set("Origin", "https://example.com")
+        .set("Access-Control-Request-Method", "GET")
+        .set("Access-Control-Request-Headers", "authorization, content-type")
+        .expect(204);
+
+      expect(response.headers["access-control-allow-headers"]).toEqual(
+        "authorization, content-type"
+      );
+    });
+  });
+
   describe("/mcp/ routes", () => {
     test("GET /mcp/ without auth returns 401", async () => {
       await request(server).get("/mcp/").expect(401);

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -89,6 +89,32 @@ export const MARKDOWN_PATCH_VERSION_HEADER = "Markdown-Patch-Version";
 export const MARKDOWN_PATCH_V1_SUNSET = "6.0";
 
 /**
+ * CORS options shared by the main API router and the MCP router.
+ *
+ * `exposedHeaders: "*"` is what lets a browser client read any of the response
+ * headers this API sets to tell it something -- `Content-Location`, `Deprecation`,
+ * `Markdown-Patch-Warnings`, `Content-Disposition`, `ETag`, `X-Response-Time`, and
+ * `Mcp-Session-Id`. Without it the `cors` package omits Access-Control-Expose-Headers
+ * altogether and only the seven CORS-safelisted headers are readable from JavaScript.
+ *
+ * The wildcard is used rather than an enumerated list so a header added later cannot
+ * be forgotten here. Two caveats come with it, and both are satisfied today:
+ *
+ * - Per the Fetch standard the wildcard is only special for requests made *without*
+ *   credentials; in a credentialed request it is read as the literal header name `*`.
+ *   This API sends `Access-Control-Allow-Origin: *` and never
+ *   `Access-Control-Allow-Credentials`, so a credentialed request already cannot
+ *   succeed here. Should the origin policy ever gain credentials, this must become an
+ *   explicit list at the same time.
+ * - Safari only honoured the wildcard from 15.4 (March 2022). Older clients fall back
+ *   to the safelist -- no worse off than before this was set.
+ */
+const CorsOptions = {
+  methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"],
+  exposedHeaders: "*",
+};
+
+/**
  * Resolve which markdown-patch engine a request selects via the
  * {@link MARKDOWN_PATCH_VERSION_HEADER} header. The 2.0 format is the default:
  * an absent header or an explicit `"2"` selects it; `"1"` opts back into the
@@ -2238,10 +2264,10 @@ export default class RequestHandler {
       next();
     });
     this.api.use(responseTime());
-    this.api.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"] }));
+    this.api.use(cors(CorsOptions));
 
     const mcpRouter = express.Router();
-    mcpRouter.use(cors({ methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"] }));
+    mcpRouter.use(cors(CorsOptions));
     mcpRouter.use((req, res, next) => {
       if (!this.requestIsAuthenticated(req)) {
         this.returnCannedResponse(res, {


### PR DESCRIPTION
Both `cors()` calls were configured with `methods` only. The `cors` package omits `Access-Control-Expose-Headers` entirely when `exposedHeaders` is unset and never defaults it, so a browser client may read only the seven CORS-safelisted response headers. Every header this API sets to tell a client something is on the wire and readable by curl, but invisible to JavaScript.

## What that costs today

| Header | Sites | What a browser client loses |
|---|---|---|
| `Mcp-Session-Id` | MCP SDK transport | **Sessionful MCP cannot hand-shake** — the SDK's own client reads `response.headers.get('mcp-session-id')` and gets `null` |
| `Content-Location` | 9 | "Where did my write actually land" — the point of the `/active/` and `/periodic/` routes |
| `Markdown-Patch-Warnings` | 1 | A PATCH's warnings vanish; the call looks perfectly clean |
| `ETag` | Express, automatic | No conditional requests, no optimistic concurrency |
| `Content-Disposition` | 1 | Cannot honour the suggested filename |
| `Deprecation` | 4 | The markdown-patch 1.x sunset warning does not reach them |
| `X-Response-Time` | 1 | Unreadable |

`Mcp-Session-Id` is what moves this from a missed courtesy to a broken feature. The rest were degraded quietly.

This project explicitly has browser consumers — the web extension — so this is not a hypothetical class of client.

## The change

One shared `CorsOptions` constant, carrying `exposedHeaders: "*"`, used by both the main API router and the MCP router.

The wildcard was chosen over an enumerated list because nothing would enforce an explicit list staying in sync, and two of the affected headers (`ETag`, `Mcp-Session-Id`) are set by Express and the MCP SDK rather than by this codebase — they would sit in such a list as literals regardless.

## Why this does not add risk

The change adds a response header to responses that previously had none of it. It cannot alter status codes, bodies, or the set of headers actually sent — only whether a browser is permitted to read headers that were already there. Concretely, the scenarios where it could plausibly be *worse* than the status quo, and what bounds each:

- **Credentialed requests.** Per the Fetch standard the wildcard is only special for requests made *without* credentials; a credentialed request reads it as the literal header name `*`. Bounded because this API sends `Access-Control-Allow-Origin: *` and never `Access-Control-Allow-Credentials`, so a credentialed request already cannot succeed here. Recorded in the constant's doc comment: if the origin policy ever gains credentials, this must become an explicit list at the same time.
- **Old Safari.** The wildcard is honoured only from Safari 15.4 (March 2022). Bounded because older clients fall back to the CORS safelist — exactly where they were before this change. No regression, just no fix.
- **Information exposure.** The wildcard exposes response headers to script on a cross-origin page, but `Set-Cookie` is excluded by the Fetch standard and this API sets no other header carrying a secret; the API key travels in the request direction, never the response. Any origin could already read the full response *body* — `Access-Control-Allow-Origin: *` with bearer auth means an attacker holding the key needs no browser at all, and one without it gets a 401 whose headers say nothing.
- **The request direction.** Untouched, and pinned by a test in both the unit and integration suites, so a later change to the response direction cannot quietly cost us header reflection on preflight.

## Verification

TDD per AGENTS.md: the failing tests are their own commit (`a63c178`), the fix follows.

- **Unit — run, passing.** 3 new tests in `src/requestHandler.test.ts`. Full suite 423/423 green, 420 before. The two response-direction tests were confirmed to fail against `main` and pass after the fix; the preflight test passed both before and after, which is what establishes that the request direction was never the defect.
- **`npm run typecheck`, `npm run lint`, `npm run build`** all clean. The 4 lint warnings are pre-existing sentence-case warnings in the settings UI, untouched here.
- **Integration — written, NOT run.** 4 new tests in `src/integration/cors.test.ts`, including one that performs a real `POST` returning `Content-Location` and asserts the header and the directive together. See the gap below.

## Honest gaps

- **The integration suite never ran.** No `OBSIDIAN_API_KEY` in the session that wrote this, so all 13 suites fail at import. The 4 new tests are unexecuted and **want a run before this merges.**
- **No live browser check.** The `Mcp-Session-Id` consequence is read out of the MCP SDK's source, not watched in a browser. The claim that this fixes sessionful MCP for browser clients is therefore reasoned, not observed — it is the one assertion here I would most want confirmed by someone with a browser.
- **`docs/src/` is untouched.** AGENTS.md asks that REST, MCP, OpenAPI and README move together, but exposed headers are a transport-level concern belonging to no single endpoint and there is no obvious OpenAPI home for them. Documented in a new README section instead, with the TOC regenerated. Say the word if you would rather it were documented per-endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
