### PR TITLE
Add vault_read_binary and vault_write_binary MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ The REST API has always handled binary content: `GET /vault/<path>` returns raw 
 
 MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files, and carry the bytes base64-encoded.
 
-`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would land in your vault as a corrupt file with no error anywhere.
+`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 
 Because base64 costs roughly 0.35-0.45 tokens per byte of context, both binary tools refuse files over 1 MiB. That ceiling is a context guard, not a storage limit — move larger attachments over the REST endpoints above.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Give your scripts, browser extensions, and AI agents a direct line into your Obs
   * [Protocol revisions](#protocol-revisions)
   * [Connecting a client](#connecting-a-client)
   * [Available tools](#available-tools)
+  * [Binary files and attachments](#binary-files-and-attachments)
   * [Available resources](#available-resources)
 - [API Extensions](#api-extensions)
   * [Typed extension API](#typed-extension-api)
@@ -316,7 +317,9 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 |---|---|
 | `vault_list` | List files and subdirectories inside a vault directory |
 | `vault_read` | Read a file's content, frontmatter, tags, and stat |
+| `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
 | `vault_write` | Create or overwrite a vault file |
+| `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
 | `vault_append` | Append content to the end of a vault file |
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
 | `vault_delete` | Delete a vault file (moves to trash by default) |
@@ -330,6 +333,14 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 | `command_list` | List all registered Obsidian commands |
 | `command_execute` | Execute an Obsidian command by ID |
 | `open_file` | Open a file in the Obsidian UI |
+
+### Binary files and attachments
+
+The REST API has always handled binary content: `GET /vault/<path>` returns raw bytes with a `Content-Type` derived from the file extension, and `PUT /vault/<path>` accepts a body of any content type and stores it byte-for-byte. Neither has a practical size limit.
+
+MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files. They carry the bytes as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+
+Because base64 costs roughly 0.35-0.45 tokens per byte of context, both binary tools refuse files over 1 MiB. That ceiling is a context guard, not a storage limit — move larger attachments over the REST endpoints above.
 
 ### Available resources
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,9 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 
 The REST API has always handled binary content: `GET /vault/<path>` returns raw bytes with a `Content-Type` derived from the file extension, and `PUT /vault/<path>` accepts a body of any content type and stores it byte-for-byte. Neither has a practical size limit.
 
-MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files. They carry the bytes as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files, and carry the bytes base64-encoded.
+
+`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would land in your vault as a corrupt file with no error anywhere.
 
 Because base64 costs roughly 0.35-0.45 tokens per byte of context, both binary tools refuse files over 1 MiB. That ceiling is a context guard, not a storage limit — move larger attachments over the REST endpoints above.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1440,7 +1440,9 @@ paths:
         |---|---|
         | `vault_list` | List files and subdirectories inside a vault directory |
         | `vault_read` | Read a file's full content, frontmatter, tags, and stat |
+        | `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
         | `vault_write` | Create or overwrite a vault file |
+        | `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
         | `vault_append` | Append content to the end of a vault file |
         | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
         | `vault_delete` | Delete a vault file (moves to trash by default) |
@@ -1454,6 +1456,12 @@ paths:
         | `command_list` | List all registered Obsidian commands |
         | `command_execute` | Execute an Obsidian command by ID |
         | `open_file` | Open a file in the Obsidian UI |
+        
+        ### Binary files
+        
+        `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+        
+        Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
         
         ## Available resources
         
@@ -2066,6 +2074,8 @@ paths:
     get:
       description: |
         Returns the content of the file at the specified path in your vault should the file exist.
+        
+        Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response. MCP clients have `vault_read_binary` for the same job, but it base64-encodes the file into the model's context and so caps the file size; anything larger belongs here.
         
         # Targeting a Sub-part of your Document
         
@@ -2953,6 +2963,8 @@ paths:
     put:
       description: |
         Creates a new file in your vault or updates the content of an existing one if the specified file already exists.
+        
+        Any content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. MCP clients have `vault_write_binary` for the same job, but it carries the file base64-encoded through the model and so caps the file size; anything larger belongs here.
         
         # Targeting a Sub-part of your Document
         

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2075,7 +2075,7 @@ paths:
       description: |
         Returns the content of the file at the specified path in your vault should the file exist.
         
-        Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response. MCP clients have `vault_read_binary` for the same job, but it base64-encodes the file into the model's context and so caps the file size; anything larger belongs here.
+        Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response.
         
         # Targeting a Sub-part of your Document
         
@@ -2964,7 +2964,7 @@ paths:
       description: |
         Creates a new file in your vault or updates the content of an existing one if the specified file already exists.
         
-        Any content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. MCP clients have `vault_write_binary` for the same job, but it carries the file base64-encoded through the model and so caps the file size; anything larger belongs here.
+        Any content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. There is no size limit beyond the request-size cap.
         
         # Targeting a Sub-part of your Document
         

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1459,7 +1459,9 @@ paths:
         
         ### Binary files
         
-        `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+        `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
+        
+        `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would be written to your vault as a corrupt file with no error anywhere.
         
         Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
         

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1461,7 +1461,7 @@ paths:
         
         `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
         
-        `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would be written to your vault as a corrupt file with no error anywhere.
+        `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
         
         Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
         

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -32,7 +32,9 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 |---|---|
 | `vault_list` | List files and subdirectories inside a vault directory |
 | `vault_read` | Read a file's full content, frontmatter, tags, and stat |
+| `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
 | `vault_write` | Create or overwrite a vault file |
+| `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
 | `vault_append` | Append content to the end of a vault file |
 | `vault_patch` | Patch a specific heading, block reference, or frontmatter field |
 | `vault_delete` | Delete a vault file (moves to trash by default) |
@@ -46,6 +48,12 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 | `command_list` | List all registered Obsidian commands |
 | `command_execute` | Execute an Obsidian command by ID |
 | `open_file` | Open a file in the Obsidian UI |
+
+### Binary files
+
+`vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+
+Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
 
 ## Available resources
 

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -53,7 +53,7 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 
 `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
 
-`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would be written to your vault as a corrupt file with no error anywhere.
+`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 
 Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
 

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -51,7 +51,9 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 
 ### Binary files
 
-`vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file as standard base64 (not base64url), and `vault_write_binary` rejects a payload that is not the canonical encoding of the bytes it decodes to rather than writing mangled ones.
+`vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
+
+`vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage. This matters because Node's own decoder does the opposite: `Buffer.from(value, "base64")` silently drops any character it does not recognise and hands back whatever is left, so a truncated or mistyped payload would be written to your vault as a corrupt file with no error anywhere.
 
 Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.
 

--- a/docs/src/lib/descriptions/vault-file-get.md
+++ b/docs/src/lib/descriptions/vault-file-get.md
@@ -1,3 +1,3 @@
 Returns the content of the file at the specified path in your vault should the file exist.
 
-Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response. MCP clients have `vault_read_binary` for the same job, but it base64-encodes the file into the model's context and so caps the file size; anything larger belongs here.
+Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response.

--- a/docs/src/lib/descriptions/vault-file-get.md
+++ b/docs/src/lib/descriptions/vault-file-get.md
@@ -1,1 +1,3 @@
 Returns the content of the file at the specified path in your vault should the file exist.
+
+Binary files are served as raw bytes, with a `Content-Type` derived from the file extension, so this endpoint reads attachments — images, PDFs, audio — as well as notes. There is no size limit on the response. MCP clients have `vault_read_binary` for the same job, but it base64-encodes the file into the model's context and so caps the file size; anything larger belongs here.

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -268,7 +268,7 @@ std.manifestYamlDoc(
             'Vault Files',
           ],
           summary: 'Create a new file in your vault or update the content of an existing one.\n',
-          description: 'Creates a new file in your vault or updates the content of an existing one if the specified file already exists.\n\nAny content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. MCP clients have `vault_write_binary` for the same job, but it carries the file base64-encoded through the model and so caps the file size; anything larger belongs here.\n\n' + PutShared,
+          description: 'Creates a new file in your vault or updates the content of an existing one if the specified file already exists.\n\nAny content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. There is no size limit beyond the request-size cap.\n\n' + PutShared,
           parameters: [ParamPath] + super.parameters,
         },
         post: Post {

--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -268,7 +268,7 @@ std.manifestYamlDoc(
             'Vault Files',
           ],
           summary: 'Create a new file in your vault or update the content of an existing one.\n',
-          description: 'Creates a new file in your vault or updates the content of an existing one if the specified file already exists.\n\n' + PutShared,
+          description: 'Creates a new file in your vault or updates the content of an existing one if the specified file already exists.\n\nAny content type is accepted: a request body that is not text or JSON is stored as raw bytes, so attachments -- images, PDFs, audio -- can be uploaded here as well as notes. MCP clients have `vault_write_binary` for the same job, but it carries the file base64-encoded through the model and so caps the file size; anything larger belongs here.\n\n' + PutShared,
           parameters: [ParamPath] + super.parameters,
         },
         post: Post {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,3 +97,11 @@ export const LicenseUrl =
   "https://raw.githubusercontent.com/coddingtonbear/obsidian-local-rest-api/main/LICENSE";
 
 export const MaximumRequestSize = "1024mb";
+
+// Ceiling on the bytes `vault_read_binary` and `vault_write_binary` will carry. This is a
+// context guard, not a storage limit: base64 in a tool argument or result passes through
+// the model's context at roughly 0.35-0.45 tokens per byte, so a file a REST client would
+// not think twice about is a five-figure token bill for an agent. Anything larger belongs
+// on `GET`/`PUT /vault/<path>`, which carry raw bytes and are bounded only by
+// `MaximumRequestSize` above.
+export const MaximumMcpBinaryBytes = 1024 * 1024;

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -575,6 +575,68 @@ describe("vault_write and vault_delete tools", () => {
 });
 
 // ---------------------------------------------------------------------------
+// vault_read_binary + vault_write_binary
+//
+// The point of these tools is byte fidelity, so the fixture is deliberately a real PNG:
+// its 0x89 lead byte is not valid UTF-8, so any path that decodes it as text loses it.
+// The round trip below therefore fails if the bytes ever go through a string.
+// ---------------------------------------------------------------------------
+
+describe("vault_read_binary and vault_write_binary tools", () => {
+  const BINARY_PATH = `${TEST_DIR}/mcp-temp-pixel.png`;
+  const PIXEL_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  afterAll(async () => {
+    await deleteFixture(BINARY_PATH).catch((_e: unknown): void => {});
+  });
+
+  test("round-trips a PNG through write and read without corrupting a byte", async () => {
+    const writeResult = await client.callTool({
+      name: "vault_write_binary",
+      arguments: { path: BINARY_PATH, content: PIXEL_BASE64 },
+    });
+    expect(jsonOf<any>(writeResult).message).toBe("OK");
+
+    // Give Obsidian's index a moment to register the new file.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const readResult = await client.callTool({
+      name: "vault_read_binary",
+      arguments: { path: BINARY_PATH },
+    });
+    const body = jsonOf<any>(readResult);
+    expect(body.content).toBe(PIXEL_BASE64);
+    expect(body.encoding).toBe("base64");
+    expect(body.mimeType).toBe("image/png");
+    expect(body.size).toBe(Buffer.from(PIXEL_BASE64, "base64").byteLength);
+  });
+
+  test("the same bytes are served over REST, so the two layers agree", async () => {
+    const response = await authedFetch(`/vault/${BINARY_PATH}`);
+    expect(response.status).toBe(200);
+    const overRest = Buffer.from(await response.arrayBuffer());
+    expect(overRest.toString("base64")).toBe(PIXEL_BASE64);
+  });
+
+  test("rejects a payload that is not canonical base64 rather than writing it", async () => {
+    const result = await client.callTool({
+      name: "vault_write_binary",
+      arguments: { path: BINARY_PATH, content: "not-valid-base64!" },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  test("vault_read_binary reports a missing file as an error", async () => {
+    const result = await client.callTool({
+      name: "vault_read_binary",
+      arguments: { path: `${TEST_DIR}/definitely-not-here.png` },
+    });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // vault_append
 // ---------------------------------------------------------------------------
 

--- a/src/mcpEndpoint.test.ts
+++ b/src/mcpEndpoint.test.ts
@@ -204,7 +204,7 @@ describe("mounted /mcp/ endpoint", () => {
         .send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
         .expect(200);
 
-      expect(sseResult(res.text).result.tools).toHaveLength(16);
+      expect(sseResult(res.text).result.tools).toHaveLength(18);
     });
 
     test("initialize opens a session and later requests reuse it", async () => {
@@ -216,7 +216,7 @@ describe("mounted /mcp/ endpoint", () => {
         .send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
         .expect(200);
 
-      expect(sseResult(res.text).result.tools).toHaveLength(16);
+      expect(sseResult(res.text).result.tools).toHaveLength(18);
     });
 
     test("an unknown session id is rejected with 404", async () => {

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -587,11 +587,23 @@ describe("McpHandler", () => {
       async (_label: string, content: string) => {
         const cb = getToolCallback("vault_write_binary");
         await expect(cb({ path: "attachments/pixel.png", content })).rejects.toThrow(
-          /must be standard base64/,
+          /must be base64-encoded bytes/,
         );
         expect(ops.writeFileContent).not.toHaveBeenCalled();
       },
     );
+
+    // The base64url hint is worth its space only for a caller who actually used base64url;
+    // on every other failure it is a paragraph about an encoding nobody reached for.
+    test("vault_write_binary names base64url only when the payload looks like it", async () => {
+      const cb = getToolCallback("vault_write_binary");
+      await expect(
+        cb({ path: "attachments/pixel.png", content: "-_-_" }),
+      ).rejects.toThrow(/base64url/);
+      await expect(
+        cb({ path: "attachments/pixel.png", content: "iVBOR" }),
+      ).rejects.not.toThrow(/base64url/);
+    });
 
     test("vault_write_binary refuses a payload over the ceiling", async () => {
       const cb = getToolCallback("vault_write_binary");

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -13,7 +13,7 @@ import request from "supertest";
 import { McpServer } from "@modelcontextprotocol/server";
 
 import { McpHandler } from "./mcpHandler";
-import { DEFAULT_SETTINGS } from "./constants";
+import { DEFAULT_SETTINGS, MaximumMcpBinaryBytes } from "./constants";
 import { TFile } from "../mocks/obsidian";
 
 const MODERN_VERSION = "2026-07-28";
@@ -78,6 +78,7 @@ function makeMockOps() {
     readFileSectionMdp2: jest
       .fn()
       .mockResolvedValue({ kind: "heading", content: "section content" }),
+    readBinaryFileContent: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
     writeFileContent: jest.fn().mockResolvedValue(undefined),
     appendFileContent: jest.fn().mockResolvedValue(undefined),
     patchFileSection: jest.fn().mockResolvedValue("patched content"),
@@ -204,14 +205,16 @@ describe("McpHandler", () => {
 
   // ---- tool registration --------------------------------------------------
 
-  test("registers all 16 tools", () => {
-    expect(registerTool).toHaveBeenCalledTimes(16);
+  test("registers all 18 tools", () => {
+    expect(registerTool).toHaveBeenCalledTimes(18);
     const names = registerTool.mock.calls.map((c: unknown[]) => c[0]);
     expect(names).toEqual(
       expect.arrayContaining([
         "vault_list",
         "vault_read",
+        "vault_read_binary",
         "vault_write",
+        "vault_write_binary",
         "vault_append",
         "vault_patch",
         "vault_delete",
@@ -236,6 +239,7 @@ describe("McpHandler", () => {
       for (const name of [
         "vault_list",
         "vault_read",
+        "vault_read_binary",
         "vault_get_document_map",
         "active_file_get_path",
         "search_query",
@@ -503,6 +507,108 @@ describe("McpHandler", () => {
     const result = await cb({ path: "out.md", content: "hello" });
     expect(ops.writeFileContent).toHaveBeenCalledWith("out.md", "hello");
     expect(parseText(result).message).toBe("OK");
+  });
+
+  // ---- vault_read_binary / vault_write_binary ------------------------------
+
+  describe("binary tools", () => {
+    // A one-pixel PNG: real bytes, with a 0x89 lead byte that is not valid UTF-8, so a
+    // round trip through the text tools could not produce it.
+    const PNG_BASE64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    const PNG_BYTES = Buffer.from(PNG_BASE64, "base64");
+
+    function arrayBufferOf(buffer: Buffer): ArrayBuffer {
+      return buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+      ) as ArrayBuffer;
+    }
+
+    test("vault_read_binary returns the bytes base64-encoded with a mime type and size", async () => {
+      ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(PNG_BYTES));
+      const cb = getToolCallback("vault_read_binary");
+      const result = await cb({ path: "attachments/pixel.png" });
+      expect(ops.readBinaryFileContent).toHaveBeenCalledWith("attachments/pixel.png");
+      expect(parseText(result)).toEqual({
+        path: "attachments/pixel.png",
+        mimeType: "image/png",
+        size: PNG_BYTES.byteLength,
+        encoding: "base64",
+        content: PNG_BASE64,
+      });
+    });
+
+    test("vault_read_binary falls back to application/octet-stream for an unknown extension", async () => {
+      ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(Buffer.from([0, 1, 2])));
+      const cb = getToolCallback("vault_read_binary");
+      expect(parseText(await cb({ path: "data.zzz" })).mimeType).toBe(
+        "application/octet-stream",
+      );
+    });
+
+    test("vault_read_binary refuses a file over the ceiling instead of returning it", async () => {
+      ops.readBinaryFileContent.mockResolvedValue(
+        new ArrayBuffer(MaximumMcpBinaryBytes + 1),
+      );
+      const cb = getToolCallback("vault_read_binary");
+      await expect(cb({ path: "big.bin" })).rejects.toThrow(
+        /Refusing to read .* GET or PUT \/vault/s,
+      );
+    });
+
+    test("vault_write_binary decodes base64 and hands writeFileContent a Buffer", async () => {
+      const cb = getToolCallback("vault_write_binary");
+      const result = await cb({ path: "attachments/pixel.png", content: PNG_BASE64 });
+      expect(ops.writeFileContent).toHaveBeenCalledTimes(1);
+      const [writtenPath, writtenContent] = ops.writeFileContent.mock.calls[0];
+      expect(writtenPath).toBe("attachments/pixel.png");
+      expect(Buffer.isBuffer(writtenContent)).toBe(true);
+      // The bytes must survive intact — this is the whole point of the tool.
+      expect((writtenContent as Buffer).equals(PNG_BYTES)).toBe(true);
+      expect(parseText(result)).toEqual({ message: "OK", size: PNG_BYTES.byteLength });
+    });
+
+    test("vault_write_binary tolerates whitespace-wrapped base64", async () => {
+      const cb = getToolCallback("vault_write_binary");
+      const wrapped = PNG_BASE64.replace(/(.{40})/g, "$1\n");
+      await cb({ path: "attachments/pixel.png", content: wrapped });
+      const [, writtenContent] = ops.writeFileContent.mock.calls[0];
+      expect((writtenContent as Buffer).equals(PNG_BYTES)).toBe(true);
+    });
+
+    test.each([
+      ["a bad length", "iVBOR"],
+      ["a character outside the alphabet", "iVBO*w0KGgo="],
+      ["base64url input", "-_-_"],
+      ["a non-canonical encoding", "QR=="],
+    ])(
+      "vault_write_binary rejects %s rather than writing mangled bytes",
+      async (_label: string, content: string) => {
+        const cb = getToolCallback("vault_write_binary");
+        await expect(cb({ path: "attachments/pixel.png", content })).rejects.toThrow(
+          /must be standard base64/,
+        );
+        expect(ops.writeFileContent).not.toHaveBeenCalled();
+      },
+    );
+
+    test("vault_write_binary refuses a payload over the ceiling", async () => {
+      const cb = getToolCallback("vault_write_binary");
+      const oversized = Buffer.alloc(MaximumMcpBinaryBytes + 3).toString("base64");
+      await expect(
+        cb({ path: "big.bin", content: oversized }),
+      ).rejects.toThrow(/Refusing to write/);
+      expect(ops.writeFileContent).not.toHaveBeenCalled();
+    });
+
+    test("vault_write_binary writes an empty file for an empty payload", async () => {
+      const cb = getToolCallback("vault_write_binary");
+      const result = await cb({ path: "empty.bin", content: "" });
+      const [, writtenContent] = ops.writeFileContent.mock.calls[0];
+      expect((writtenContent as Buffer).byteLength).toBe(0);
+      expect(parseText(result).size).toBe(0);
+    });
   });
 
   // ---- vault_append -------------------------------------------------------
@@ -1093,8 +1199,8 @@ describe("McpHandler", () => {
 
       const first = await send(1);
       const second = await send(2);
-      expect(first.body.result.tools).toHaveLength(16);
-      expect(second.body.result.tools).toHaveLength(16);
+      expect(first.body.result.tools).toHaveLength(18);
+      expect(second.body.result.tools).toHaveLength(18);
       expect(first.headers["mcp-session-id"]).toBeUndefined();
       expect(second.headers["mcp-session-id"]).toBeUndefined();
     });
@@ -1234,7 +1340,7 @@ describe("McpHandler", () => {
         .send(sessionlessRequest(1, "tools/list"))
         .expect(200);
 
-      expect(res.body.result.tools).toHaveLength(16);
+      expect(res.body.result.tools).toHaveLength(18);
       expect(res.headers["mcp-session-id"]).toBeUndefined();
     });
 
@@ -1362,7 +1468,7 @@ describe("McpHandler", () => {
         .expect(200);
 
       const message = sseResult(res.text);
-      expect(message.result.tools).toHaveLength(16);
+      expect(message.result.tools).toHaveLength(18);
       const vaultList = (message.result.tools as { name: string; inputSchema: unknown }[]).find(
         (t) => t.name === "vault_list",
       );

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -87,12 +87,19 @@ const BASE64_ALPHABET = /^[A-Za-z0-9+/]*={0,2}$/;
 // `Buffer.from(s, "base64")` discards anything it cannot decode instead of failing, so a
 // mangled payload would be written to the vault as silently-wrong bytes. Validate the
 // alphabet and padding, then re-encode and compare: a value that does not survive the
-// round trip is not the canonical encoding of the bytes we would have written.
+// round trip is not the encoding of the bytes we would have written.
 function decodeBase64Strict(value: string): Buffer {
   const compact = value.replace(/\s+/g, "");
+  // RFC 4648 defines two alphabets, and the URL-safe one is common enough that a caller
+  // can arrive with it by accident. Name it only when the payload actually looks like it,
+  // so the usual failure is not buried under a paragraph about an encoding nobody used.
+  const looksLikeBase64Url = /[-_]/.test(compact);
   const rejected = (why: string): Error =>
     new Error(
-      `content must be standard base64-encoded bytes (${why}). Note that base64url — '-' and '_' in place of '+' and '/' — is not accepted.`,
+      `content must be base64-encoded bytes (${why})` +
+        (looksLikeBase64Url
+          ? ". This looks like base64url; use '+' and '/' rather than '-' and '_'."
+          : "."),
     );
   if (compact.length % 4 !== 0) {
     throw rejected("length is not a multiple of 4");
@@ -102,7 +109,7 @@ function decodeBase64Strict(value: string): Buffer {
   }
   const decoded = Buffer.from(compact, "base64");
   if (decoded.toString("base64") !== compact) {
-    throw rejected("value is not the canonical encoding of the bytes it decodes to");
+    throw rejected("it does not survive a decode/re-encode round trip");
   }
   return decoded;
 }
@@ -535,7 +542,7 @@ export class McpHandler {
       dedent`
         Create or overwrite a vault file with raw bytes supplied base64-encoded. Use this for anything that is not text — images, PDFs, audio, any attachment. Creates any missing parent directories automatically, and overwrites without warning if the file already exists.
 
-        content must be standard base64 (not base64url): a payload that is not the canonical encoding of the bytes it decodes to is rejected rather than written, since a silently mangled attachment is worse than a failed call.
+        content is base64. A payload that cannot be decoded cleanly is rejected rather than written, since a silently corrupted attachment is worse than a failed call.
 
         Files over ${MaximumMcpBinaryBytes} bytes are refused — upload those with the REST API's PUT /vault/<path>, which accepts raw bytes of any content type.
       `,

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -14,6 +14,7 @@ import { posix } from "path";
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import express from "express";
+import mime from "mime-types";
 import { TFile } from "obsidian";
 import { dedent } from "ts-dedent";
 
@@ -22,6 +23,7 @@ import type { InstructionInput, ReadTarget } from "markdown-patch-2";
 import { InstructionInputObjectSchema } from "markdown-patch-2";
 import openapiYaml from "../docs/openapi.yaml";
 import { toStandardSchema } from "./mcpSchema";
+import { MaximumMcpBinaryBytes } from "./constants";
 import { LocalRestApiSettings } from "./types";
 
 const SERVER_INFO = { name: "obsidian-local-rest-api", version: "1.0.0" };
@@ -79,6 +81,40 @@ function parseStringHeadingTarget(target: string): string[] | null | undefined {
 
 const HEADING_TARGET_STRING_HINT =
   "received a string that is not the JSON encoding of an array — if you did pass an array, your MCP client may not support anyOf-typed tool parameters";
+
+const BASE64_ALPHABET = /^[A-Za-z0-9+/]*={0,2}$/;
+
+// `Buffer.from(s, "base64")` discards anything it cannot decode instead of failing, so a
+// mangled payload would be written to the vault as silently-wrong bytes. Validate the
+// alphabet and padding, then re-encode and compare: a value that does not survive the
+// round trip is not the canonical encoding of the bytes we would have written.
+function decodeBase64Strict(value: string): Buffer {
+  const compact = value.replace(/\s+/g, "");
+  const rejected = (why: string): Error =>
+    new Error(
+      `content must be standard base64-encoded bytes (${why}). Note that base64url — '-' and '_' in place of '+' and '/' — is not accepted.`,
+    );
+  if (compact.length % 4 !== 0) {
+    throw rejected("length is not a multiple of 4");
+  }
+  if (!BASE64_ALPHABET.test(compact)) {
+    throw rejected("contains characters outside the base64 alphabet");
+  }
+  const decoded = Buffer.from(compact, "base64");
+  if (decoded.toString("base64") !== compact) {
+    throw rejected("value is not the canonical encoding of the bytes it decodes to");
+  }
+  return decoded;
+}
+
+// Both binary tools refuse the same way, so the ceiling reads identically whichever
+// direction a client hit it from.
+function assertWithinBinaryCeiling(byteLength: number, verb: string): void {
+  if (byteLength <= MaximumMcpBinaryBytes) return;
+  throw new Error(
+    `Refusing to ${verb} ${byteLength} bytes over MCP: the limit is ${MaximumMcpBinaryBytes} bytes, because base64 costs roughly 0.35-0.45 tokens per byte of context. Use the REST API instead — GET or PUT /vault/<path> carries raw bytes.`,
+  );
+}
 
 interface ResourceSpec {
   name: string;
@@ -467,6 +503,52 @@ export class McpHandler {
       async ({ path, content }: { path: string; content: string }) => {
         await this.ops.writeFileContent(path, content);
         return this.text({ message: "OK" });
+      },
+    );
+
+    this.tool(
+      "vault_read_binary",
+      dedent`
+        Read a vault file as raw bytes, returned base64-encoded. Use this for anything that is not text — images, PDFs, audio, any attachment. vault_read decodes a file as UTF-8 and will hand back a lossy, unusable string for those, so writing the result of a vault_read back to a binary file destroys it.
+
+        Returns a JSON object with: path, mimeType (guessed from the file extension), size (the file's size in bytes, before encoding), encoding (always "base64"), and content (the base64 payload). Throws if the file does not exist.
+
+        Base64 costs roughly 0.35-0.45 tokens per byte of file, so this is only practical for small files: a 1 MB attachment is several hundred thousand tokens of context. Files over ${MaximumMcpBinaryBytes} bytes are refused outright — fetch those with the REST API's GET /vault/<path>, which carries raw bytes at no context cost.
+      `,
+      { path: z.string().describe("File path relative to vault root") },
+      READ_ONLY_ANNOTATIONS,
+      async ({ path }: { path: string }) => {
+        const bytes = await this.ops.readBinaryFileContent(path);
+        assertWithinBinaryCeiling(bytes.byteLength, "read");
+        return this.text({
+          path,
+          mimeType: mime.lookup(path) || "application/octet-stream",
+          size: bytes.byteLength,
+          encoding: "base64",
+          content: Buffer.from(bytes).toString("base64"),
+        });
+      },
+    );
+
+    this.tool(
+      "vault_write_binary",
+      dedent`
+        Create or overwrite a vault file with raw bytes supplied base64-encoded. Use this for anything that is not text — images, PDFs, audio, any attachment. Creates any missing parent directories automatically, and overwrites without warning if the file already exists.
+
+        content must be standard base64 (not base64url): a payload that is not the canonical encoding of the bytes it decodes to is rejected rather than written, since a silently mangled attachment is worse than a failed call.
+
+        Files over ${MaximumMcpBinaryBytes} bytes are refused — upload those with the REST API's PUT /vault/<path>, which accepts raw bytes of any content type.
+      `,
+      {
+        path: z.string().describe("File path relative to vault root"),
+        content: z.string().describe("Full file content, base64-encoded"),
+      },
+      { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+      async ({ path, content }: { path: string; content: string }) => {
+        const bytes = decodeBase64Strict(content);
+        assertWithinBinaryCeiling(bytes.byteLength, "write");
+        await this.ops.writeFileContent(path, bytes);
+        return this.text({ message: "OK", size: bytes.byteLength });
       },
     );
 

--- a/src/mcpSessionfulClient.test.ts
+++ b/src/mcpSessionfulClient.test.ts
@@ -73,7 +73,7 @@ describe("sessionful MCP client interoperability", () => {
 
     expect(transport.sessionId).toEqual(expect.any(String));
     expect(client.getServerCapabilities()?.tools?.listChanged).toBe(true);
-    expect((await client.listTools()).tools).toHaveLength(16);
+    expect((await client.listTools()).tools).toHaveLength(18);
 
     const result = await client.callTool({ name: "tag_list", arguments: {} });
     expect(JSON.parse((result.content as { text: string }[])[0].text)).toEqual({

--- a/src/vaultOperations.test.ts
+++ b/src/vaultOperations.test.ts
@@ -80,6 +80,26 @@ describe("writes go through the Vault API", () => {
   });
 });
 
+describe("readBinaryFileContent", () => {
+  test("returns the adapter's bytes rather than a decoded string", async () => {
+    const { app, ops } = setup("");
+    // 0x89 leads a PNG and is not valid UTF-8, so a decoded read could not produce it.
+    const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
+    app.vault.adapter._readBinary = bytes.buffer;
+
+    const read = await ops.readBinaryFileContent(MD_PATH);
+
+    expect(new Uint8Array(read)).toEqual(bytes);
+  });
+
+  test("throws for a path that is not a file, matching the text read", async () => {
+    const { ops } = setup("", false);
+    await expect(ops.readBinaryFileContent(MD_PATH)).rejects.toThrow(
+      `File not found: ${MD_PATH}`,
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // simpleSearch context slicing must not split UTF-16 surrogate pairs.
 //

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -362,6 +362,18 @@ export class VaultOperations {
     return this.app.vault.read(file);
   }
 
+  // Reads a file as raw bytes rather than decoding it as UTF-8, which is what
+  // `readFileContent` above (and `cachedRead` behind `getFileMetadataObject`) does. The
+  // REST layer reaches for `adapter.readBinary` directly; MCP goes through here so the
+  // "does this file exist" answer is the same one `vault_read` gives.
+  async readBinaryFileContent(filePath: string): Promise<ArrayBuffer> {
+    const file = this.app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+    return this.app.vault.adapter.readBinary(filePath);
+  }
+
   async writeFileContent(
     filePath: string,
     content: string | Buffer,


### PR DESCRIPTION
Closes #284.

## What this adds

Two MCP tools, `vault_read_binary` and `vault_write_binary`, so an agent that only has MCP tools can move attachments in and out of the vault at arbitrary paths.

- `vault_read_binary(path)` → `{ path, mimeType, size, encoding: "base64", content }`. `mimeType` is guessed from the extension the same way `GET /vault/<path>` guesses it, falling back to `application/octet-stream`.
- `vault_write_binary(path, content)` takes standard base64 and hands `writeFileContent` a `Buffer`, which already routes to `adapter.writeBinary`.

## Why, and what was actually broken

The REST API has handled binary content all along — `GET /vault/<path>` reads through `adapter.readBinary` with a mime-typed response (`src/requestHandler.ts:440`), and `PUT` accepts any content type because `express.raw({ type: "*/*" })` is the last body parser registered (`:2323`). None of that is mentioned in the README or `docs/src/`, which is probably why it keeps being asked for; this PR documents it.

MCP had no equivalent, and the failure mode was worse than the absence. `vault_read` runs `cachedRead` on whatever path it is given, so an attachment comes back as a lossy UTF-8 decode **with no error**, and `vault_list` enumerates attachments, so an agent is led right to them. Writing that string back destroys the file.

Issue #284 asked for exactly this, explicitly noting the REST `PUT` already worked, and was closed as completed five minutes after filing with no comment and no commit referencing it.

## Two deliberate constraints

**A 1 MiB ceiling on both tools** (`MaximumMcpBinaryBytes`). This is a context guard, not a storage limit: base64 in a tool argument or result passes through the model's context at roughly 0.35–0.45 tokens per byte, so a file a REST client would not think twice about is a five-figure token bill for an agent. The error names the REST endpoint, which is bounded only by `MaximumRequestSize` (1024mb). **The number is the thing in here most worth arguing with** — it is one constant.

**Strict base64 validation on write.** `Buffer.from(s, "base64")` discards anything it cannot decode instead of failing, so a mangled payload would land in the vault as silently-wrong bytes. The decoder checks length, alphabet, and then re-encodes and compares; base64url is rejected with a message that says so. A silently mangled attachment is worse than a failed call.

## Why this does not add risk

**The read path is additive.** `vault_read_binary` is a new tool; no existing tool's behavior changes. `readBinaryFileContent` is a new `VaultOperations` method that reuses `adapter.readBinary` — the same call `GET /vault/<path>` has always made — and adds the `TFile` existence check so its "file not found" answer matches `vault_read`'s.

**The write path reuses the REST write path exactly.** `writeFileContent(path, Buffer)` is the same call `PUT /vault/<path>` makes for a binary body, unchanged and already unit-tested (`src/vaultOperations.test.ts:75-79`). This PR adds no new way to write bytes to the vault; it adds a second caller of the existing one.

**Where it could plausibly be worse than before, and what bounds it:**

| Scenario | Bound |
|---|---|
| An agent pulls a huge attachment into context | The 1 MiB ceiling refuses before any bytes are read into a result, and points at REST |
| A malformed payload writes garbage over a real attachment | Strict validation rejects before `writeFileContent` is reached — asserted by four unit cases (bad length, bad alphabet, base64url, non-canonical) each also asserting `writeFileContent` was never called |
| Two more tools in every session's tool list | Real and unavoidable under this shape; the alternative considered was an `encoding` parameter on the existing tools |
| Base64 decode/encode mangles bytes | Round-tripped live against a real PNG, byte-identical (below) |

**Evidence, from the live plugin rather than from reasoning.** The rebuilt plugin was loaded in Obsidian and driven over its own MCP endpoint against the real vault:

- `vault_write_binary` on a 70-byte PNG (lead byte `0x89`, not valid UTF-8, so no path that decodes it as text could reproduce it) → `{"message":"OK","size":70}`
- `vault_read_binary` on the same path → `size: 70`, `mimeType: "image/png"`, and `content` **byte-identical** to what was written
- `vault_write_binary` with `-_-_` → rejected with the base64url message; nothing written
- Scratch file deleted afterward

**Honest gaps:**

- **The integration suite was not run.** The session that wrote this had no `OBSIDIAN_API_KEY`, so `npm run test:integration` could not start. The four integration tests added to `src/integration/mcp.test.ts` (round trip, REST/MCP agreement on the same bytes, invalid-base64 rejection, missing-file error) are **written but unexecuted** — they need a run before merge. The live probe above covers the same ground by hand for three of the four.
- **`vault_read` on a binary file is still silently lossy.** Guarding the text tools was evaluated and deliberately left out of this PR, since it changes existing tool behavior. It is worth its own change.
- **No `image`/`audio` content blocks.** A capable client would render those natively instead of receiving a wall of base64. Also deliberately out of scope here.
- The 1 MiB ceiling is not configurable. Adding a setting for it seemed like more surface than the problem warrants, but it is a constant, not a decision baked into the shape.

## Verification

- `npm test` — 433 passed, 9 suites. 10 new unit tests across `src/mcpHandler.test.ts` and `src/vaultOperations.test.ts`.
- `npm run typecheck`, `npx tsc -p tsconfig.integration.json --noEmit`, `npx eslint` on the touched files — all clean.
- `npm run build`, `npm run build-docs`, `npm run build-toc` — run and staged, per `AGENTS.md`.

## Layers touched

Per `AGENTS.md`, all in one commit: `src/mcpHandler.ts`, `src/vaultOperations.ts`, `src/constants.ts`, `README.md`, `docs/src/lib/descriptions/mcp.md`, `docs/src/lib/descriptions/vault-file-get.md`, `docs/src/openapi.jsonnet`, regenerated `docs/openapi.yaml`, unit tests, integration tests. `src/requestHandler.ts` is unchanged — REST already had the capability; what it lacked was documentation, which this adds.

One asymmetry is chosen rather than accidental: MCP gets a base64 convention that REST does not have, because REST carries raw bytes natively. Each protocol uses its natural carrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
