### PR TITLE
Refuse a vault_read of a file whose bytes are not valid UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ The REST API has always handled binary content: `GET /vault/<path>` returns raw 
 
 MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files, and carry the bytes base64-encoded.
 
-`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
 
 `vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 | Tool | Description |
 |---|---|
 | `vault_list` | List files and subdirectories inside a vault directory |
-| `vault_read` | Read a file's content, frontmatter, tags, and stat |
+| `vault_read` | Read a text file's content, frontmatter, tags, and stat; refuses anything that is not valid UTF-8 |
 | `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
 | `vault_write` | Create or overwrite a vault file |
 | `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
@@ -346,6 +346,10 @@ The exact config syntax varies by client; see the [Quick start](#mcp-clients) ex
 The REST API has always handled binary content: `GET /vault/<path>` returns raw bytes with a `Content-Type` derived from the file extension, and `PUT /vault/<path>` accepts a body of any content type and stores it byte-for-byte. Neither has a practical size limit.
 
 MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files, and carry the bytes base64-encoded.
+
+`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+
+`vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
 
 `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1439,7 +1439,7 @@ paths:
         | Tool | Description |
         |---|---|
         | `vault_list` | List files and subdirectories inside a vault directory |
-        | `vault_read` | Read a file's full content, frontmatter, tags, and stat |
+        | `vault_read` | Read a text file's full content, frontmatter, tags, and stat; refuses anything that is not valid UTF-8 |
         | `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
         | `vault_write` | Create or overwrite a vault file |
         | `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
@@ -1460,6 +1460,10 @@ paths:
         ### Binary files
         
         `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
+        
+        `vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+        
+        `vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
         
         `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
         

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1461,7 +1461,7 @@ paths:
         
         `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
         
-        `vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+        `vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
         
         `vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
         

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -53,7 +53,7 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 
 `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
 
-`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
 
 `vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
 

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -31,7 +31,7 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 | Tool | Description |
 |---|---|
 | `vault_list` | List files and subdirectories inside a vault directory |
-| `vault_read` | Read a file's full content, frontmatter, tags, and stat |
+| `vault_read` | Read a text file's full content, frontmatter, tags, and stat; refuses anything that is not valid UTF-8 |
 | `vault_read_binary` | Read a file as raw bytes, base64-encoded, for attachments `vault_read` would corrupt |
 | `vault_write` | Create or overwrite a vault file |
 | `vault_write_binary` | Create or overwrite a vault file from base64-encoded raw bytes |
@@ -52,6 +52,10 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 ### Binary files
 
 `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
+
+`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes survive a decode, not whether that character appears.
+
+`vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
 
 `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -637,6 +637,70 @@ describe("vault_read_binary and vault_write_binary tools", () => {
 });
 
 // ---------------------------------------------------------------------------
+// vault_read's refusal of non-text files
+//
+// The unit tests hand the handler a decoded string and mock what a re-read returns; only
+// here does a real file go through Obsidian's own reader, which is what decides whether
+// U+FFFD actually shows up in the decoded text. Both directions are covered, because the
+// guard is only worth having if it separates them.
+// ---------------------------------------------------------------------------
+
+describe("vault_read on a non-text file", () => {
+  const PNG_PATH = `${TEST_DIR}/mcp-temp-refused.png`;
+  const PIXEL_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+  // A note whose text genuinely contains the replacement character — the false positive
+  // the cheap check would produce on its own.
+  const MARKER_PATH = `${TEST_DIR}/mcp-temp-marker.md`;
+  const MARKER_BODY = `# Marker\n\nA pasted glyph survived as ${String.fromCodePoint(0xfffd)} here.\n`;
+
+  beforeAll(async () => {
+    await client.callTool({
+      name: "vault_write_binary",
+      arguments: { path: PNG_PATH, content: PIXEL_BASE64 },
+    });
+    await client.callTool({
+      name: "vault_write",
+      arguments: { path: MARKER_PATH, content: MARKER_BODY },
+    });
+    // Give Obsidian's index a moment to register both new files.
+    await new Promise((r) => setTimeout(r, 300));
+  });
+
+  afterAll(async () => {
+    await deleteFixture(PNG_PATH).catch((_e: unknown): void => {});
+    await deleteFixture(MARKER_PATH).catch((_e: unknown): void => {});
+  });
+
+  test("refuses the PNG and points at vault_read_binary", async () => {
+    const result = await client.callTool({
+      name: "vault_read",
+      arguments: { path: PNG_PATH },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toMatch(/not valid UTF-8/);
+    expect(textOf(result)).toMatch(/vault_read_binary/);
+  });
+
+  test("still reads a text file containing a literal replacement character", async () => {
+    const result = await client.callTool({
+      name: "vault_read",
+      arguments: { path: MARKER_PATH },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(jsonOf<any>(result).content).toBe(MARKER_BODY);
+  });
+
+  test("the REST layer is unchanged and still serves the PNG's raw bytes", async () => {
+    const response = await authedFetch(`/vault/${PNG_PATH}`);
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString("base64")).toBe(
+      PIXEL_BASE64,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // vault_append
 // ---------------------------------------------------------------------------
 

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -639,18 +639,18 @@ describe("vault_read_binary and vault_write_binary tools", () => {
 // ---------------------------------------------------------------------------
 // vault_read's refusal of non-text files
 //
-// The unit tests hand the handler a decoded string and mock what a re-read returns; only
-// here does a real file go through Obsidian's own reader, which is what decides whether
-// U+FFFD actually shows up in the decoded text. Both directions are covered, because the
-// guard is only worth having if it separates them.
+// The unit tests hand the handler bytes through a mocked ops layer; only here do a real
+// file's bytes come back from Obsidian's own adapter and get decoded. Both directions are
+// covered, because the guard is only worth having if it separates them.
 // ---------------------------------------------------------------------------
 
 describe("vault_read on a non-text file", () => {
   const PNG_PATH = `${TEST_DIR}/mcp-temp-refused.png`;
   const PIXEL_BASE64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
-  // A note whose text genuinely contains the replacement character — the false positive
-  // the cheap check would produce on its own.
+  // A note whose text genuinely contains the replacement character: its own bytes are
+  // valid UTF-8, so it must read normally. This is the file a check that looked for the
+  // character itself would wrongly refuse.
   const MARKER_PATH = `${TEST_DIR}/mcp-temp-marker.md`;
   const MARKER_BODY = `# Marker\n\nA pasted glyph survived as ${String.fromCodePoint(0xfffd)} here.\n`;
 
@@ -680,6 +680,18 @@ describe("vault_read on a non-text file", () => {
     expect(result.isError).toBe(true);
     expect(textOf(result)).toMatch(/not valid UTF-8/);
     expect(textOf(result)).toMatch(/vault_read_binary/);
+  });
+
+  // The refusal is on the file's bytes, so it lands before the target is looked up: a
+  // targeted read of an attachment says the file is not text, rather than that the
+  // heading was not found in it.
+  test("refuses a targeted read of the PNG for the same reason", async () => {
+    const result = await client.callTool({
+      name: "vault_read",
+      arguments: { path: PNG_PATH, targetType: "heading", target: ["Anything"] },
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toMatch(/not valid UTF-8/);
   });
 
   test("still reads a text file containing a literal replacement character", async () => {

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -23,6 +23,10 @@ const LEGACY_VERSION = "2025-06-18";
 // would make the assertion agree with the SDK by construction.
 const NEWEST_SESSIONFUL_VERSION = "2025-11-25";
 
+// What the mock vault holds at `test.md`. `vault_read` reads a file's raw bytes and
+// decodes them itself, so this is what every read of that path hands on to the ops layer.
+const NOTE_TEXT = "# Alpha\n\nsection content\n";
+
 // The real McpServer is used throughout: the 2026-07-28 serving entries build one per
 // request from McpHandler's factory, so there is nothing to substitute. Registrations are
 // observed by spying on the prototype and then building a server directly.
@@ -39,6 +43,17 @@ function makeMockFile(path = "test.md"): TFile {
   f.path = path;
   f.basename = path.replace(/\.md$/, "");
   return f;
+}
+
+function arrayBufferOf(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer;
+}
+
+function bytesOf(text: string): ArrayBuffer {
+  return arrayBufferOf(Buffer.from(text, "utf-8"));
 }
 
 function makeMockOps() {
@@ -78,7 +93,7 @@ function makeMockOps() {
     readFileSectionMdp2: jest
       .fn()
       .mockResolvedValue({ kind: "heading", content: "section content" }),
-    readBinaryFileContent: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+    readBinaryFileContent: jest.fn().mockResolvedValue(bytesOf(NOTE_TEXT)),
     writeFileContent: jest.fn().mockResolvedValue(undefined),
     appendFileContent: jest.fn().mockResolvedValue(undefined),
     patchFileSection: jest.fn().mockResolvedValue("patched content"),
@@ -320,6 +335,7 @@ describe("McpHandler", () => {
       expect(ops.readFileSectionMdp2).toHaveBeenCalledWith(
         expect.objectContaining({ path: "test.md" }),
         { targetType: "heading", target: ["Alpha", "Subsection"] },
+        NOTE_TEXT,
       );
       expect(ops.getFileMetadataObject).not.toHaveBeenCalled();
       expect(parseText(result)).toBe("section content");
@@ -340,6 +356,7 @@ describe("McpHandler", () => {
           target: ["Alpha"],
           scope: "markerAndContent",
         },
+        NOTE_TEXT,
       );
     });
 
@@ -361,6 +378,7 @@ describe("McpHandler", () => {
       expect(ops.readFileSectionMdp2).toHaveBeenCalledWith(
         expect.anything(),
         { targetType: "heading", target: [disambiguated] },
+        NOTE_TEXT,
       );
     });
 
@@ -384,6 +402,7 @@ describe("McpHandler", () => {
       expect(ops.readFileSectionMdp2).toHaveBeenCalledWith(
         expect.anything(),
         { targetType: "heading", target: ["Parent", "Child"] },
+        NOTE_TEXT,
       );
     });
 
@@ -409,6 +428,7 @@ describe("McpHandler", () => {
       expect(ops.readFileSectionMdp2).toHaveBeenCalledWith(
         expect.anything(),
         { targetType: "block", target: "beta-block" },
+        NOTE_TEXT,
       );
     });
 
@@ -419,6 +439,7 @@ describe("McpHandler", () => {
       expect(ops.readFileSectionMdp2).toHaveBeenCalledWith(
         expect.anything(),
         { targetType: "block", target: disambiguated },
+        NOTE_TEXT,
       );
     });
 
@@ -460,69 +481,78 @@ describe("McpHandler", () => {
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
         "base64",
       );
-      // What Obsidian hands back for those bytes, rather than a hand-written stand-in.
-      const PNG_AS_LOSSY_TEXT = PNG_BYTES.toString("utf-8");
-
-      function arrayBufferOf(buffer: Buffer): ArrayBuffer {
-        return buffer.buffer.slice(
-          buffer.byteOffset,
-          buffer.byteOffset + buffer.byteLength,
-        ) as ArrayBuffer;
-      }
-
-      function readsBack(text: string, bytes: Buffer) {
-        ops.getFileMetadataObject.mockResolvedValue({
-          content: text,
-          tags: [],
-          frontmatter: {},
-          stat: { ctime: 0, mtime: 0, size: bytes.byteLength },
-          path: "attachments/pixel.png",
-          links: [],
-          backlinks: [],
-          unresolvedLinks: [],
-        });
-        ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(bytes));
-      }
 
       test("refuses a file whose bytes are not valid UTF-8, naming vault_read_binary", async () => {
-        readsBack(PNG_AS_LOSSY_TEXT, PNG_BYTES);
+        ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(PNG_BYTES));
         const cb = getToolCallback("vault_read");
         await expect(cb({ path: "attachments/pixel.png" })).rejects.toThrow(
           /not valid UTF-8.*vault_read_binary/s,
         );
+        expect(ops.getFileMetadataObject).not.toHaveBeenCalled();
       });
 
-      // The replacement character is a hint, not a verdict: a note that contains one is
-      // still a note, and refusing it would be a regression for its author.
-      test("returns a text file that contains a literal replacement character", async () => {
+      // The replacement character is not the test: a note that contains one is still a
+      // note, because its own bytes are perfectly good UTF-8. Refusing it would be a
+      // regression for its author.
+      test("reads a text file that contains a literal replacement character", async () => {
         const text = `# Notes\n\nA pasted glyph survived as � here.\n`;
-        readsBack(text, Buffer.from(text, "utf-8"));
+        ops.readBinaryFileContent.mockResolvedValue(bytesOf(text));
         const cb = getToolCallback("vault_read");
-        expect(parseText(await cb({ path: "notes.md" })).content).toBe(text);
+        await cb({ path: "notes.md" });
+        expect(ops.getFileMetadataObject).toHaveBeenCalledWith(
+          expect.anything(),
+          undefined,
+          true,
+          text,
+        );
       });
 
-      test("does not re-read the bytes of an ordinary text file", async () => {
+      // The whole point of decoding the bytes here rather than checking the text Obsidian
+      // decoded: the file is read once, and the ops layer is handed what that read
+      // produced instead of reading it again behind `cachedRead`.
+      test("reads the file once and hands the decoded text to the metadata read", async () => {
         const cb = getToolCallback("vault_read");
         await cb({ path: "test.md" });
-        expect(ops.readBinaryFileContent).not.toHaveBeenCalled();
+        expect(ops.readBinaryFileContent).toHaveBeenCalledTimes(1);
+        expect(ops.readBinaryFileContent).toHaveBeenCalledWith("test.md");
+        expect(ops.getFileMetadataObject).toHaveBeenCalledWith(
+          expect.anything(),
+          undefined,
+          true,
+          NOTE_TEXT,
+        );
       });
 
-      test("refuses a targeted read whose section decoded lossily", async () => {
-        ops.readFileSectionMdp2.mockResolvedValue({
-          kind: "heading",
-          content: PNG_AS_LOSSY_TEXT,
-        });
+      // A byte order mark is content: keeping it is what makes the string a caller reads
+      // the same bytes a write of it would put back.
+      test("keeps a leading byte order mark", async () => {
+        // Spelled by code point: a literal BOM is invisible in an editor and would read
+        // as an ordinary heading line.
+        const text = `${String.fromCodePoint(0xfeff)}# Notes\n`;
+        ops.readBinaryFileContent.mockResolvedValue(bytesOf(text));
+        const cb = getToolCallback("vault_read");
+        await cb({ path: "notes.md" });
+        expect(ops.getFileMetadataObject).toHaveBeenCalledWith(
+          expect.anything(),
+          undefined,
+          true,
+          text,
+        );
+      });
+
+      test("refuses a targeted read of a file whose bytes are not valid UTF-8", async () => {
         ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(PNG_BYTES));
         const cb = getToolCallback("vault_read");
         await expect(
           cb({ path: "attachments/pixel.png", targetType: "heading", target: ["Alpha"] }),
         ).rejects.toThrow(/not valid UTF-8/);
+        expect(ops.readFileSectionMdp2).not.toHaveBeenCalled();
       });
 
       // A frontmatter read can return a number, an array, an object — anything YAML
-      // parses to. Only a string can carry the marker, and the rest must not crash on
-      // the way past.
-      test("leaves a non-string frontmatter value alone", async () => {
+      // parses to. The guard is on the file's bytes rather than on what was extracted
+      // from them, so a non-string value passes through untouched.
+      test("returns a non-string frontmatter value untouched", async () => {
         ops.readFileSectionMdp2.mockResolvedValue({ kind: "frontmatter", value: 3 });
         const cb = getToolCallback("vault_read");
         const result = await cb({
@@ -531,6 +561,13 @@ describe("McpHandler", () => {
           target: "priority",
         });
         expect(parseText(result)).toBe(3);
+      });
+
+      test("does not read the file when the arguments are malformed", async () => {
+        const cb = getToolCallback("vault_read");
+        await expect(cb({ path: "test.md", targetType: "heading" })).rejects.toThrow(
+          "targetType and target must be provided together",
+        );
         expect(ops.readBinaryFileContent).not.toHaveBeenCalled();
       });
     });

--- a/src/mcpHandler.test.ts
+++ b/src/mcpHandler.test.ts
@@ -449,6 +449,91 @@ describe("McpHandler", () => {
         "targetType and target must be provided together",
       );
     });
+
+    // A file that is not text decodes anyway, with U+FFFD standing in for every byte
+    // sequence UTF-8 could not represent — so the danger is that the read looks like it
+    // worked. These cover both sides of that: bytes that were genuinely mangled, and text
+    // that merely contains the same character.
+    describe("non-text files", () => {
+      // A one-pixel PNG: real bytes, whose 0x89 lead byte is not valid UTF-8.
+      const PNG_BYTES = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      // What Obsidian hands back for those bytes, rather than a hand-written stand-in.
+      const PNG_AS_LOSSY_TEXT = PNG_BYTES.toString("utf-8");
+
+      function arrayBufferOf(buffer: Buffer): ArrayBuffer {
+        return buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        ) as ArrayBuffer;
+      }
+
+      function readsBack(text: string, bytes: Buffer) {
+        ops.getFileMetadataObject.mockResolvedValue({
+          content: text,
+          tags: [],
+          frontmatter: {},
+          stat: { ctime: 0, mtime: 0, size: bytes.byteLength },
+          path: "attachments/pixel.png",
+          links: [],
+          backlinks: [],
+          unresolvedLinks: [],
+        });
+        ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(bytes));
+      }
+
+      test("refuses a file whose bytes are not valid UTF-8, naming vault_read_binary", async () => {
+        readsBack(PNG_AS_LOSSY_TEXT, PNG_BYTES);
+        const cb = getToolCallback("vault_read");
+        await expect(cb({ path: "attachments/pixel.png" })).rejects.toThrow(
+          /not valid UTF-8.*vault_read_binary/s,
+        );
+      });
+
+      // The replacement character is a hint, not a verdict: a note that contains one is
+      // still a note, and refusing it would be a regression for its author.
+      test("returns a text file that contains a literal replacement character", async () => {
+        const text = `# Notes\n\nA pasted glyph survived as � here.\n`;
+        readsBack(text, Buffer.from(text, "utf-8"));
+        const cb = getToolCallback("vault_read");
+        expect(parseText(await cb({ path: "notes.md" })).content).toBe(text);
+      });
+
+      test("does not re-read the bytes of an ordinary text file", async () => {
+        const cb = getToolCallback("vault_read");
+        await cb({ path: "test.md" });
+        expect(ops.readBinaryFileContent).not.toHaveBeenCalled();
+      });
+
+      test("refuses a targeted read whose section decoded lossily", async () => {
+        ops.readFileSectionMdp2.mockResolvedValue({
+          kind: "heading",
+          content: PNG_AS_LOSSY_TEXT,
+        });
+        ops.readBinaryFileContent.mockResolvedValue(arrayBufferOf(PNG_BYTES));
+        const cb = getToolCallback("vault_read");
+        await expect(
+          cb({ path: "attachments/pixel.png", targetType: "heading", target: ["Alpha"] }),
+        ).rejects.toThrow(/not valid UTF-8/);
+      });
+
+      // A frontmatter read can return a number, an array, an object — anything YAML
+      // parses to. Only a string can carry the marker, and the rest must not crash on
+      // the way past.
+      test("leaves a non-string frontmatter value alone", async () => {
+        ops.readFileSectionMdp2.mockResolvedValue({ kind: "frontmatter", value: 3 });
+        const cb = getToolCallback("vault_read");
+        const result = await cb({
+          path: "test.md",
+          targetType: "frontmatter",
+          target: "priority",
+        });
+        expect(parseText(result)).toBe(3);
+        expect(ops.readBinaryFileContent).not.toHaveBeenCalled();
+      });
+    });
   });
 
   // ---- vault_get_document_map ---------------------------------------------

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -114,24 +114,29 @@ function decodeBase64Strict(value: string): Buffer {
   return decoded;
 }
 
-// A file that is not text still "reads": Obsidian decodes it as UTF-8 and substitutes
-// U+FFFD for every malformed byte sequence rather than failing, so `vault_read` on a PNG
-// hands back a lossy string and reports success. Write that string back through
-// `vault_write` and the file is destroyed, with nothing along the way looking like an
-// error.
+// A file that is not text still "reads" through Obsidian's own reader: it decodes as
+// UTF-8 and substitutes U+FFFD for every malformed byte sequence rather than failing, so
+// `vault_read` on a PNG hands back a lossy string and reports success. Write that string
+// back through `vault_write` and the file is destroyed, with nothing along the way
+// looking like an error.
 //
-// U+FFFD in the decoded text is the only trace that substitution happened — but it is not
-// proof of it, because a text file may contain the character deliberately. So it is used
-// as a cheap trigger rather than a verdict: text without it decoded losslessly and costs
-// nothing beyond the scan, and only text with it pays for re-reading the raw bytes to
-// answer the question exactly, by the same decode/re-encode round trip
-// `decodeBase64Strict` uses above.
-// Spelled by code point rather than as a literal: the character itself renders as an
-// unidentifiable box in most editors, which is a poor thing to have to recognise here.
-const REPLACEMENT_CHARACTER = String.fromCodePoint(0xfffd);
-
-function survivesUtf8RoundTrip(bytes: Buffer): boolean {
-  return Buffer.from(bytes.toString("utf-8"), "utf-8").equals(bytes);
+// So `vault_read` decodes the bytes itself, with a decoder that throws instead of
+// substituting. That is the exact question the tool needs answered — would handing this
+// back as a string lose bytes? — rather than a guess at what the file is, and it is one
+// read: the same bytes then serve the content, which is why every read path below takes
+// the text it produced instead of reading the file again.
+//
+// `ignoreBOM` keeps a leading U+FEFF in the string rather than swallowing it, so what a
+// caller reads is byte-for-byte what a `vault_write` of it would put back, and so a
+// BOM-carrying note reads exactly as it did before this check existed.
+function decodeUtf8Strict(bytes: ArrayBuffer, path: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch {
+    throw new Error(
+      `Refusing to read ${path} as text: its bytes are not valid UTF-8, so decoding them loses data and the content returned here could not be written back without destroying the file. Read it with vault_read_binary, or fetch the raw bytes over the REST API with GET /vault/<path>.`,
+    );
+  }
 }
 
 // Both binary tools refuse the same way, so the ceiling reads identically whichever
@@ -413,16 +418,10 @@ export class McpHandler {
     return file;
   }
 
-  // Refuses text that only exists because bytes were mangled on the way in. See
-  // REPLACEMENT_CHARACTER above for why the cheap check comes first and what the raw-byte
-  // read is settling.
-  private async assertDecodedLosslessly(path: string, decoded: string): Promise<void> {
-    if (!decoded.includes(REPLACEMENT_CHARACTER)) return;
-    const bytes = Buffer.from(await this.ops.readBinaryFileContent(path));
-    if (survivesUtf8RoundTrip(bytes)) return;
-    throw new Error(
-      `Refusing to read ${path} as text: its bytes are not valid UTF-8, so decoding them loses data and the content returned here could not be written back without destroying the file. Read it with vault_read_binary, or fetch the raw bytes over the REST API with GET /vault/<path>.`,
-    );
+  // The one read behind every `vault_read`: raw bytes, decoded strictly. See
+  // `decodeUtf8Strict` above for why the read is a binary one.
+  private async readTextStrict(path: string): Promise<string> {
+    return decodeUtf8Strict(await this.ops.readBinaryFileContent(path), path);
   }
 
   private registerResources(): void {
@@ -505,6 +504,10 @@ export class McpHandler {
         if (scope !== undefined && (targetType == null || target == null)) {
           throw new Error("scope requires targetType and target");
         }
+        // Read once, up front, and hand the text to whichever path answers: a malformed
+        // argument should not cost a file read, but neither should a targeted read of a
+        // file this tool is about to refuse.
+        const content = await this.readTextStrict(path);
         if (targetType && target != null) {
           let address: ReadTarget;
           if (targetType === "heading") {
@@ -525,19 +528,10 @@ export class McpHandler {
           if (scope !== undefined) {
             address.scope = scope;
           }
-          const result = await this.ops.readFileSectionMdp2(file, address);
-          const section = result.kind === "frontmatter" ? result.value : result.content;
-          // A targeted read only ever sees its own section, so this guards what is
-          // actually being handed back rather than the whole file. In practice a binary
-          // file has no headings, blocks, or frontmatter to address, so the refusal a
-          // caller meets here is usually the target lookup's own.
-          if (typeof section === "string") {
-            await this.assertDecodedLosslessly(path, section);
-          }
-          return this.text(section);
+          const result = await this.ops.readFileSectionMdp2(file, address, content);
+          return this.text(result.kind === "frontmatter" ? result.value : result.content);
         }
-        const meta = await this.ops.getFileMetadataObject(file);
-        await this.assertDecodedLosslessly(path, meta.content);
+        const meta = await this.ops.getFileMetadataObject(file, undefined, true, content);
         return this.text(meta);
       },
     );

--- a/src/mcpHandler.ts
+++ b/src/mcpHandler.ts
@@ -114,6 +114,26 @@ function decodeBase64Strict(value: string): Buffer {
   return decoded;
 }
 
+// A file that is not text still "reads": Obsidian decodes it as UTF-8 and substitutes
+// U+FFFD for every malformed byte sequence rather than failing, so `vault_read` on a PNG
+// hands back a lossy string and reports success. Write that string back through
+// `vault_write` and the file is destroyed, with nothing along the way looking like an
+// error.
+//
+// U+FFFD in the decoded text is the only trace that substitution happened — but it is not
+// proof of it, because a text file may contain the character deliberately. So it is used
+// as a cheap trigger rather than a verdict: text without it decoded losslessly and costs
+// nothing beyond the scan, and only text with it pays for re-reading the raw bytes to
+// answer the question exactly, by the same decode/re-encode round trip
+// `decodeBase64Strict` uses above.
+// Spelled by code point rather than as a literal: the character itself renders as an
+// unidentifiable box in most editors, which is a poor thing to have to recognise here.
+const REPLACEMENT_CHARACTER = String.fromCodePoint(0xfffd);
+
+function survivesUtf8RoundTrip(bytes: Buffer): boolean {
+  return Buffer.from(bytes.toString("utf-8"), "utf-8").equals(bytes);
+}
+
 // Both binary tools refuse the same way, so the ceiling reads identically whichever
 // direction a client hit it from.
 function assertWithinBinaryCeiling(byteLength: number, verb: string): void {
@@ -393,6 +413,18 @@ export class McpHandler {
     return file;
   }
 
+  // Refuses text that only exists because bytes were mangled on the way in. See
+  // REPLACEMENT_CHARACTER above for why the cheap check comes first and what the raw-byte
+  // read is settling.
+  private async assertDecodedLosslessly(path: string, decoded: string): Promise<void> {
+    if (!decoded.includes(REPLACEMENT_CHARACTER)) return;
+    const bytes = Buffer.from(await this.ops.readBinaryFileContent(path));
+    if (survivesUtf8RoundTrip(bytes)) return;
+    throw new Error(
+      `Refusing to read ${path} as text: its bytes are not valid UTF-8, so decoding them loses data and the content returned here could not be written back without destroying the file. Read it with vault_read_binary, or fetch the raw bytes over the REST API with GET /vault/<path>.`,
+    );
+  }
+
   private registerResources(): void {
     this.addResourceSpec(
       "openapi-spec",
@@ -431,6 +463,8 @@ export class McpHandler {
         Read a vault file's content and metadata. Returns a JSON object with: content (full markdown text), path, tags (array of tag strings), frontmatter (parsed YAML front-matter as an object), stat ({ctime, mtime, size}), links (array of vault-relative paths this file links to), backlinks (array of vault-relative paths of files that link here), and unresolvedLinks (array of link text in this file that does not resolve to an existing vault file). Throws if the file does not exist.
 
         When targetType and target are both provided, returns only the matched section as a plain string (markdown) or JSON value (frontmatter) instead of the full object. To save context, call vault_get_document_map first to identify headings, block IDs, or frontmatter keys, and prefer targeted reads over full reads for anything but short files.
+
+        This tool reads text. A file whose bytes are not valid UTF-8 — an image, a PDF, any attachment — is refused rather than returned as the lossy string decoding it would produce; read those with vault_read_binary instead.
       `,
       {
         path: z.string().describe("File path relative to vault root"),
@@ -492,9 +526,18 @@ export class McpHandler {
             address.scope = scope;
           }
           const result = await this.ops.readFileSectionMdp2(file, address);
-          return this.text(result.kind === "frontmatter" ? result.value : result.content);
+          const section = result.kind === "frontmatter" ? result.value : result.content;
+          // A targeted read only ever sees its own section, so this guards what is
+          // actually being handed back rather than the whole file. In practice a binary
+          // file has no headings, blocks, or frontmatter to address, so the refusal a
+          // caller meets here is usually the target lookup's own.
+          if (typeof section === "string") {
+            await this.assertDecodedLosslessly(path, section);
+          }
+          return this.text(section);
         }
         const meta = await this.ops.getFileMetadataObject(file);
+        await this.assertDecodedLosslessly(path, meta.content);
         return this.text(meta);
       },
     );

--- a/src/vaultOperations.test.ts
+++ b/src/vaultOperations.test.ts
@@ -87,6 +87,82 @@ describe("writes go through the Vault API", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Content the caller has already read replaces the read these methods would do.
+//
+// MCP's vault_read reads a file's raw bytes so that it can refuse one whose bytes are
+// not valid UTF-8, and then needs exactly the text these two methods would otherwise
+// fetch for themselves. Passing it in is what keeps that guard to a single read of the
+// file; a caller that omits it reads as it always did.
+// ---------------------------------------------------------------------------
+
+describe("supplied content stands in for a second read", () => {
+  function withFile(existingContent: string): {
+    app: App;
+    ops: VaultOperations;
+    file: TFile;
+  } {
+    const { app, ops } = setup(existingContent);
+    const file = new TFile();
+    file.path = MD_PATH;
+    app.vault._getAbstractFileByPath = file;
+    return { app, ops, file };
+  }
+
+  test("readFileSectionMdp2 reads the supplied text, not the file", async () => {
+    const { app, ops, file } = withFile("# Alpha\n\nfrom disk\n");
+    const read = jest.spyOn(app.vault.adapter, "read");
+
+    const result = await ops.readFileSectionMdp2(
+      file,
+      { targetType: "heading", target: ["Alpha"] },
+      "# Alpha\n\nsupplied\n",
+    );
+
+    expect(JSON.stringify(result)).toContain("supplied");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  test("readFileSectionMdp2 reads the file when no text is supplied", async () => {
+    const { ops, file } = withFile("# Alpha\n\nfrom disk\n");
+
+    const result = await ops.readFileSectionMdp2(file, {
+      targetType: "heading",
+      target: ["Alpha"],
+    });
+
+    expect(JSON.stringify(result)).toContain("from disk");
+  });
+
+  test("getFileMetadataObject returns the supplied text without a cachedRead", async () => {
+    const { app, ops, file } = withFile("");
+    app.vault._cachedRead = "from disk";
+    const cachedRead = jest.spyOn(app.vault, "cachedRead");
+
+    const meta = await ops.getFileMetadataObject(file, undefined, true, "supplied");
+
+    expect(meta.content).toBe("supplied");
+    expect(cachedRead).not.toHaveBeenCalled();
+  });
+
+  test("getFileMetadataObject falls back to cachedRead when no text is supplied", async () => {
+    const { app, ops, file } = withFile("");
+    app.vault._cachedRead = "from disk";
+
+    expect((await ops.getFileMetadataObject(file)).content).toBe("from disk");
+  });
+
+  // includeContent is the caller saying it does not want the body at all — a bulk search
+  // result, say — and that answer does not change because content happens to be at hand.
+  test("getFileMetadataObject still omits content when includeContent is false", async () => {
+    const { ops, file } = withFile("");
+
+    const meta = await ops.getFileMetadataObject(file, undefined, false, "supplied");
+
+    expect(meta.content).toBe("");
+  });
+});
+
 describe("readBinaryFileContent", () => {
   test("returns the adapter's bytes rather than a decoded string", async () => {
     const { app, ops } = setup("");

--- a/src/vaultOperations.ts
+++ b/src/vaultOperations.ts
@@ -232,13 +232,19 @@ export class VaultOperations {
    * address — a heading path array, a bare block id, or a frontmatter key — and
    * return the section body (headings/blocks) or parsed value (frontmatter).
    * Throws {@link TargetNotFoundError} when the address does not resolve.
+   *
+   * `content` lets a caller that has already read the file supply what it read,
+   * rather than paying for a second read — MCP's `vault_read` decodes the raw
+   * bytes itself so it can refuse a file that is not valid UTF-8, and passes the
+   * result through here.
    */
   async readFileSectionMdp2(
     file: TFile,
     target: ReadTarget,
+    content?: string,
   ): Promise<ReadResult> {
-    const content = await this.app.vault.adapter.read(file.path);
-    return readTarget(content, target);
+    const text = content ?? (await this.app.vault.adapter.read(file.path));
+    return readTarget(text, target);
   }
 
   async readFileSection(
@@ -309,10 +315,16 @@ export class VaultOperations {
     return index;
   }
 
+  /**
+   * `content`, like {@link readFileSectionMdp2}'s, is content the caller has
+   * already read: supplying it skips the `cachedRead` below. Ignored when
+   * `includeContent` is false, since then nothing is read at all.
+   */
   async getFileMetadataObject(
     file: TFile,
     backlinksIndex?: Record<string, string[]>,
     includeContent = true,
+    content?: string,
   ): Promise<FileMetadataObject> {
     const cache = await this.waitForFileCache(file);
 
@@ -348,7 +360,9 @@ export class VaultOperations {
       frontmatter: frontmatter,
       stat: file.stat,
       path: file.path,
-      content: includeContent ? await this.app.vault.cachedRead(file) : "",
+      content: includeContent
+        ? (content ?? (await this.app.vault.cachedRead(file)))
+        : "",
       links,
       backlinks,
       unresolvedLinks,


### PR DESCRIPTION
Follow-up to #345, from your review comment on it: *"Should we perhaps consider making things error loudly if you try to use `vault_read` or `vault_write` with non-text content?"* — and then, once we'd talked it through, *"let's definitely do error loudly when `vault_read` is used to read a binary file. I suspect it's impossible to determine whether the content is binary or text on the `vault_write` side, and if so, I'm OK with our not doing anything there."*

So this is the read side only.

## What was broken

`vault_read` decodes a file as UTF-8 and hands back whatever that produces. Point it at a PNG and you get a lossy, unusable string and a successful-looking result. Write that string back through `vault_write` and the file is gone. Every step of the round trip reports success.

#345 added `vault_read_binary` and `vault_write_binary` as the way out, but deliberately left the text tools alone — which means an agent that doesn't know the new tools exist still walks into exactly the same trap, and `vault_list` will happily lead it to the attachments.

## What it does now

`vault_read` refuses a file it can't decode losslessly, and the refusal names `vault_read_binary`:

> Refusing to read `attachments/pixel.png` as text: its bytes are not valid UTF-8, so decoding them loses data and the content returned here could not be written back without destroying the file. Read it with `vault_read_binary`, or fetch the raw bytes over the REST API with `GET /vault/<path>`.

## How the check works, and why it's in two stages

The exact test is the one `decodeBase64Strict` already uses for base64, pointed at a different encoding: decode the bytes, re-encode, compare. Anything that doesn't survive that round trip lost data on the way in. The problem is that it needs the *raw bytes*, and `vault_read` doesn't have them — re-reading every file just to run the check would be a poor trade for a guard that fires almost never.

So there's a cheap trigger in front of it. Obsidian's reader substitutes U+FFFD for every byte sequence UTF-8 can't represent rather than failing, so that character is the only trace that any substitution happened. It's not *proof* of one — a note can contain the character deliberately — which is why it's a trigger and not a verdict:

- Text with no U+FFFD in it decoded losslessly. Returned as before, no extra I/O, just the scan.
- Text with U+FFFD in it pays for a re-read of the raw bytes and the round trip, which then settles it exactly.

Net effect: no false positives, and in the common case nothing is read twice.

## The two things left deliberately alone

**`vault_write` gets no equivalent guard.** You're right that content sniffing can't work there: it takes a string, and a string is text by construction. There's nothing to detect. Refusing based on the destination *path's* extension would be a different mechanism entirely, and I've left it out per your standing answer — the read-side refusal is what stops the destructive round trip from starting in the first place.

**The REST layer doesn't change.** `GET /vault/<path>` already serves raw bytes with a mime type, so it never had this problem. `AGENTS.md` says the layers move together, so I want to be explicit that this is a decision rather than a missed checkbox. Both of these are now written down in `README.md` and `docs/src/lib/descriptions/mcp.md` too, so the asymmetry doesn't read later as an oversight.

## What I decided on my own, and where you might disagree

**No escape hatch.** The task left open whether to refuse outright or offer an `allowBinary` flag for someone deliberately reading a UTF-8 file with an odd extension. I went with outright: the check is on the *bytes*, not the extension, so that caller isn't actually affected — a UTF-8 file named `.png` still reads fine. A flag would only matter for someone who wants the lossy string on purpose, and I can't construct a reason to want that. **This is the bit most worth arguing with**, since it's the one place the change is not reversible from the caller's side.

**Targeted reads are guarded on their section, not the whole file.** When you pass `targetType`/`target`, the check runs on what's actually being handed back. Guarding the whole file there would mean reading the whole file, which targeting exists to avoid. In practice a binary file has no headings, blocks, or frontmatter to address, so what a caller meets is the target lookup's own failure.

## Why this doesn't add risk

This changes the behavior of a tool already in use, so the interesting question is what it could break.

| Scenario | Bound |
|---|---|
| A note containing a literal U+FFFD is refused | It isn't — the check is the byte round trip, and that note's bytes are valid UTF-8. Covered by a unit test and by an integration test against a real file |
| Every read now costs an extra file read | Only reads of text containing U+FFFD do. Asserted directly: a unit test fails if an ordinary read touches `readBinaryFileContent` |
| A caller relying on today's lossy decode breaks | Deliberate, and the whole point — but it *is* a breaking change for anyone doing it, and the error names the tool to switch to |
| A frontmatter read returning a number/array/object hits the string check | Guarded by a `typeof` check, with a unit test for it |
| `readBinaryFileContent` throws on the re-read | Only reachable for a file that was just read successfully. If it did, `vault_read` would fail where it used to return a lossy string — a bad error rather than a silent corruption |
| The check misses something | It can only miss in the *permissive* direction (a section-targeted read of a binary file). It can't refuse a file that decodes cleanly |

**The unit tests use real bytes rather than a stand-in.** The binary fixture is an actual one-pixel PNG, and the "lossy text" it's compared against is `PNG_BYTES.toString("utf-8")` — computed in the test rather than hand-written, so it's what a decoder genuinely produces rather than what I guessed it would.

## Honest gaps

- **The integration suite was not run.** Same constraint #345 hit: this session had no `OBSIDIAN_API_KEY`, so `npm run test:integration` can't start. The three tests added to `src/integration/mcp.test.ts` (PNG refused and naming `vault_read_binary`; a note containing U+FFFD still read; REST still serving the same PNG's bytes) are **written but unexecuted**.
- **Nothing was verified against the live plugin.** Doing that means `npm run build`, which swaps the bundle your running Obsidian is on — and there's currently an open request asking you to check out `probe/metadata-cache-bootstrap` in this same checkout, so building something else into it unattended seemed like a good way to collide with you. `npm run build` has not been run; only `build-docs`.
- **The U+FFFD trigger assumes Obsidian's reader substitutes rather than throws.** That's what a WHATWG-conformant UTF-8 decoder does, and it's the behavior #345 documented, but I haven't observed it in this session.

## Verification

- `npm test` — 458 passed, 9 suites. 5 new unit tests in `src/mcpHandler.test.ts`.
- `npm run typecheck` — clean.
- `npm run lint` — clean (4 pre-existing sentence-case warnings in `main.ts`, untouched).
- `npm run build-docs` — run, `docs/openapi.yaml` regenerated and staged. No Readme headings changed, so no `build-toc`.

## Layers touched

`src/mcpHandler.ts`, `src/mcpHandler.test.ts`, `src/integration/mcp.test.ts`, `README.md`, `docs/src/lib/descriptions/mcp.md`, `docs/openapi.yaml`. No REST handler, no `publicApi.ts`, for the reasons above.
