### PR TITLE
Type the shared cors options so a misspelled key fails the typecheck

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -9,7 +9,7 @@ import forge from "node-forge";
 
 import express from "express";
 import http from "http";
-import cors from "cors";
+import cors, { CorsOptions } from "cors";
 import mime from "mime-types";
 import responseTime from "response-time";
 import queryString from "query-string";
@@ -108,8 +108,14 @@ export const MARKDOWN_PATCH_V1_SUNSET = "6.0";
  *   explicit list at the same time.
  * - Safari only honoured the wildcard from 15.4 (March 2022). Older clients fall back
  *   to the safelist -- no worse off than before this was set.
+ *
+ * The `CorsOptions` annotation is load-bearing rather than decorative: `cors()` accepts
+ * any object structurally, so an untyped literal would take `exposeHeaders` or
+ * `exposedHeader` without complaint and silently drop back to the safelist. Annotated,
+ * a misspelled key is a typecheck error -- which is the only place a mistake here can
+ * be caught, since a wrong key produces no runtime error, just a missing header.
  */
-const CorsOptions = {
+const corsOptions: CorsOptions = {
   methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"],
   exposedHeaders: "*",
 };
@@ -2264,10 +2270,10 @@ export default class RequestHandler {
       next();
     });
     this.api.use(responseTime());
-    this.api.use(cors(CorsOptions));
+    this.api.use(cors(corsOptions));
 
     const mcpRouter = express.Router();
-    mcpRouter.use(cors(CorsOptions));
+    mcpRouter.use(cors(corsOptions));
     mcpRouter.use((req, res, next) => {
       if (!this.requestIsAuthenticated(req)) {
         this.returnCannedResponse(res, {


### PR DESCRIPTION
The CORS configuration that PR 344 pulled out into a shared constant was an untyped object literal:

```ts
const CorsOptions = {
  methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "MOVE", "COPY"],
  exposedHeaders: "*",
};
```

`cors()` takes whatever object it is handed and reads the keys it recognises, so TypeScript infers the shape from the literal and accepts it no matter what the keys are called. Writing `exposeHeaders`, or `exposedHeader`, would compile clean, pass every test that does not assert on the header, and silently put browser clients back to reading only the seven CORS-safelisted response headers — which is exactly the bug PR 344 was fixing.

The thing that makes this worth a PR rather than a note is that there is no other place to catch it. A wrong key throws nothing at runtime; it just quietly omits `Access-Control-Expose-Headers`, and the failure only shows up in somebody else's browser console. So the typecheck is the only guard available, and until now it wasn't guarding anything.

## What changed

`@types/cors` is already a dependency, so this annotates the constant with the library's own `CorsOptions` type. Excess property checking on the literal then makes a misspelled key an error. The constant is renamed to `corsOptions` so the name is free for the type it now carries.

That's the whole change — no behavior change, and the existing unit tests in `src/requestHandler.test.ts` and integration tests in `src/integration/cors.test.ts` that assert `Access-Control-Expose-Headers: *` are what cover that claim.

## Evidence that the guard actually works

I didn't want to assert this one, so I temporarily misspelled the key on this branch and ran the typecheck:

```
src/requestHandler.ts(120,3): error TS2561: Object literal may only specify
known properties, but 'exposeHeaders' does not exist in type 'CorsOptions'.
Did you mean to write 'exposedHeaders'?
```

Before this change, that same misspelling typechecked clean. The key was then restored.

| Command | Result |
|---|---|
| `npm test` | 453 passed, 9 suites, 0 failures |
| `npm run typecheck` | clean |
| `npm run lint` | clean — 0 errors, 4 pre-existing sentence-case warnings in `main.ts` |

## What I decided on my own, and where you might disagree

- **No test was added.** The obvious instinct is a type-level regression test — a `@ts-expect-error` on a misspelled literal, so removing the annotation later fails the build. It would be dead weight here: `tsconfig.json` excludes `**/*.test.ts`, so `npm run typecheck` never sees test files, and `jest.config.js` runs `ts-jest` with `diagnostics: false`, so neither does the test run. A type assertion in a test file in this repo is checked by nothing. The comment above the constant says instead that the annotation is load-bearing, which is the honest version of the same protection.
- **I did not touch the other `cors` call sites or any other untyped options literal in the file.** There aren't any others for `cors`, and widening this into a general "annotate every options object" pass is a different change than the one that was asked for.
- **No docs or MCP changes.** Per AGENTS.md the layers move together, but this one is an internal constant with no observable surface: no endpoint, no tool, no response shape changes. Calling that out so it doesn't read later as a skipped checklist item.

## What I could not verify

The integration tests in `src/integration/cors.test.ts` did not run — no `OBSIDIAN_API_KEY` in a headless session, and running them means `npm run build`, which swaps the bundle your live Obsidian is on. They're unchanged by this PR and were passing on main, and since this change generates identical JavaScript, I'd expect nothing there to move. Worth a run if you're building this branch anyway.

Task: https://ticktick.com/webapp/#p/687a607c8f08c301d9df1f6c/tasks/6a92e2808f08defd958111c1
