### PR TITLE
Terminate every MCP session the integration suite opens

### DIFF
--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -71,19 +71,37 @@ function jsonOf<T = unknown>(result: ToolResult): T {
 // ---------------------------------------------------------------------------
 
 let client: Client;
+let transport: StreamableHTTPClientTransport;
 
 beforeAll(async () => {
   await ensureServerReachable();
   await resetFixture(FIXTURE_DOCUMENT, TEST_PATH);
   client = makeClient();
-  await client.connect(makeTransport());
+  transport = makeTransport();
+  await client.connect(transport);
 });
 
 afterAll(async () => {
-  await client?.close();
-  await deleteFixture(TEST_PATH);
-  // Best-effort cleanup of the temp path used by write/delete tests.
-  await deleteFixture(TEMP_PATH).catch((_e: unknown): void => {});
+  try {
+    // `client.close()` alone tears down only this end of the connection: the SDK's
+    // StreamableHTTPClientTransport.close() aborts its own request controller and never
+    // sends the DELETE, and the plugin drops a session from its map only on that DELETE
+    // (`onsessionclosed`, src/mcpHandler.ts). So closing without terminating leaves this
+    // file's session — and its `listChanged` subscription — live in the plugin for as long
+    // as Obsidian stays up, taxing every vault write in every integration file that runs
+    // after this one, and in the user's own editor afterwards.
+    //
+    // Order matters: terminateSession() sends its DELETE with the transport's own abort
+    // signal, so calling close() first would cancel the very request that ends the session.
+    // Not swallowed, either — a session we could not end is exactly the state this file is
+    // trying to avoid, and it should fail the run rather than pass quietly.
+    await transport?.terminateSession();
+  } finally {
+    await client?.close();
+    await deleteFixture(TEST_PATH);
+    // Best-effort cleanup of the temp path used by write/delete tests.
+    await deleteFixture(TEMP_PATH).catch((_e: unknown): void => {});
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -92,6 +110,36 @@ afterAll(async () => {
 // ---------------------------------------------------------------------------
 
 describe("MCP sessionful lifecycle", () => {
+  // Every session opened through `initializeAt` is registered here and terminated in
+  // afterEach. Each live session is a subscriber the plugin pushes `listChanged`
+  // notifications to on every vault write, so one left behind taxes each write-then-read-back
+  // test further down this file — enough, measured, to make `vault_patch` › "sets a
+  // frontmatter list from a native JSON array value" fail 2 runs in 4 where a clean run
+  // failed 0 in 4. Registering inside the helper rather than test by test is the point: the
+  // next sessionful test added here is cleaned up whether its author thought about this or
+  // not, which is what stops the flake reappearing somewhere else in the file.
+  const openSessions = new Set<string>();
+
+  // DELETE a session and take it off the cleanup list, so a test that terminates its own
+  // session does not leave afterEach to DELETE an id the plugin has already forgotten.
+  async function deleteSession(sessionId: string): Promise<Response> {
+    openSessions.delete(sessionId);
+    return authedFetch("/mcp/", {
+      method: "DELETE",
+      headers: { "Mcp-Session-Id": sessionId },
+    });
+  }
+
+  afterEach(async () => {
+    // Asserted rather than best-effort: a DELETE that does not answer 200 means the session
+    // is still in the plugin's map, which is the one thing this arrangement exists to
+    // prevent. Swallowing that would put the file back where it started, quietly.
+    for (const sessionId of [...openSessions]) {
+      const res = await deleteSession(sessionId);
+      expect(res.status).toBe(200);
+    }
+  });
+
   async function initializeAt(
     version: string,
   ): Promise<{ sessionId: string | null; result: any }> {
@@ -115,8 +163,10 @@ describe("MCP sessionful lifecycle", () => {
     const text = await res.text();
     const line = text.split("\n").find((l) => l.startsWith("data: "));
     if (!line) throw new Error(`No SSE data frame in initialize response: ${text}`);
+    const sessionId = res.headers.get("mcp-session-id");
+    if (sessionId) openSessions.add(sessionId);
     return {
-      sessionId: res.headers.get("mcp-session-id"),
+      sessionId,
       result: JSON.parse(line.slice("data: ".length)).result,
     };
   }
@@ -138,20 +188,11 @@ describe("MCP sessionful lifecycle", () => {
     // hanging: a real socket to a real Obsidian, not the in-process express app. The
     // hardcoded literal is deliberate — see mcpEndpoint.test.ts.
     const { sessionId, result } = await initializeAt("2025-11-25");
-    try {
-      expect(typeof sessionId).toBe("string");
-      expect(result.protocolVersion).toBe("2025-11-25");
-      expect(result.capabilities.tools.listChanged).toBe(true);
-    } finally {
-      // Terminate rather than leak. Every live session is a subscriber the plugin pushes
-      // `listChanged` notifications to on each vault write, so a session left open here
-      // slows down every write-then-read-back test further down the file — enough to have
-      // made the vault_patch frontmatter read-back race intermittently.
-      await authedFetch("/mcp/", {
-        method: "DELETE",
-        headers: { "Mcp-Session-Id": sessionId ?? "" },
-      });
-    }
+    expect(typeof sessionId).toBe("string");
+    expect(result.protocolVersion).toBe("2025-11-25");
+    expect(result.capabilities.tools.listChanged).toBe(true);
+    // The session this opened is terminated by the describe's afterEach, which runs whether
+    // the assertions above passed or threw — the try/finally this test used to carry.
   });
 
   test("an unknown session id is rejected with 404", async () => {
@@ -170,10 +211,8 @@ describe("MCP sessionful lifecycle", () => {
 
   test("DELETE terminates a session", async () => {
     const { sessionId } = await initialize();
-    const res = await authedFetch("/mcp/", {
-      method: "DELETE",
-      headers: { "Mcp-Session-Id": sessionId ?? "" },
-    });
+    if (!sessionId) throw new Error("initialize returned no Mcp-Session-Id");
+    const res = await deleteSession(sessionId);
     expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
The MCP integration suite has been leaving sessions behind inside the running plugin, and one of those leaks outlives the whole file. This closes both. It's test-only — no plugin source moves.

## The mechanism

Every sessionful MCP session is a live subscriber the plugin pushes `listChanged` notifications to on each vault write, and a session only leaves `McpHandler`'s map when a DELETE arrives (`onsessionclosed`, `src/mcpHandler.ts:292`). Nothing else expires it. So a test that runs `initialize` and walks away hands an extra broadcast to every write-then-read-back test that follows it, for the rest of the run.

That isn't theoretical. It was measured while adding the 2025-11-25 coverage: one extra leaked session made `vault_patch` › "sets a frontmatter list from a native JSON array value" fail **2 runs in 4**, where a clean run failed **0 in 4**, and DELETEing that same session put it back to **0 in 4**. The test that discovered it cleaned up after itself at the time; this is the rest of the file.

## What changed

**A cleanup net around the whole `MCP sessionful lifecycle` describe.** `initializeAt` now registers every session id it receives, and an `afterEach` DELETEs each one and asserts the plugin answered 200. Putting the registration in the helper rather than in each test is the actual point of the change: the next sessionful test added to this file gets cleaned up whether its author knew about any of this or not, which is what stops the flake resurfacing somewhere else later. Two knock-on tidies fall out of it — the 2025-11-25 test's hand-rolled `try`/`finally` is now redundant and goes, and "DELETE terminates a session" runs its DELETE through the same helper so that its id is deregistered and `afterEach` doesn't chase a session the plugin has already forgotten.

**The file-wide client, which leaked for longer than any of them.** `afterAll` called `client.close()`, and that tears down only our end: `StreamableHTTPClientTransport.close()` aborts its own request controller and never sends a DELETE (SDK 1.30.0, `dist/esm/client/streamableHttp.js:281`). The session therefore survived the file, survived every integration file that ran after it, and stayed live in the editor afterwards. `afterAll` now calls `transport.terminateSession()` first.

The ordering there is load-bearing and easy to get backwards: `terminateSession()` sends its DELETE with `signal: this._abortController?.signal`, the same controller `close()` aborts, so closing first cancels the very request that ends the session. It's in a comment so nobody helpfully "tidies" it later.

## Why I don't think this adds risk

The change can only make the suite fail in ways it couldn't before, so that's where I'd look:

- **`afterEach` asserts each DELETE returned 200, rather than swallowing failures.** A 200 is what the existing "DELETE terminates a session" test already pins for exactly this call, so the only way the assertion fires is a session the plugin genuinely would not release — which is the state the change exists to prevent, and I'd rather it be loud. The set is populated only from real `mcp-session-id` headers, and the helper removes an id the moment it is DELETEd, so there's no path where `afterEach` retries an already-terminated session and takes a 404 for it.
- **`afterAll` no longer swallows a failed termination.** Same reasoning, but it is a genuine behaviour change: a run that would previously have gone green while leaking now goes red. The fixture cleanup sits in a `finally`, so a failure there still can't leave `__integration_tests__` litter behind in the vault.
- **The 2025-11-25 test lost its `try`/`finally`.** `afterEach` runs whether a test passed or threw, so the guarantee is unchanged; it is just held one level up now.
- **Nothing here touches a code path the plugin runs.** No REST route, no MCP tool, no response shape, so per `AGENTS.md` no documentation or OpenAPI layer moves with it. Calling that out deliberately rather than leaving it to read later as a skipped checklist item.

I also checked the other two integration files that mention MCP, since the task asked for it: `src/integration/mcpSessionless.test.ts` mints no sessions at all — that's the 2026-07-28 leg, and two of its tests already assert the response carries no `mcp-session-id` — and `src/integration/cors.test.ts` only makes an unauthenticated request that is rejected with a 401 before any handshake. Neither needs anything.

## What ran, and the gap

| Command | Result |
|---|---|
| `npm test` | 453 passed, 9 suites, 0 failures |
| `npm run typecheck` | clean |
| `npm run lint` | clean — 0 errors, 4 warnings, all pre-existing sentence-case ones in `main.ts` |

**The integration suite has not been run against this, which is the honest gap, and it is a pointed one here because the integration suite is the only thing that executes any of this code.** The unit suite doesn't load `src/integration/`, so everything above is argued from the SDK's and the plugin's source rather than observed. A headless session has no `OBSIDIAN_API_KEY`.

The good news is that this one is unusually cheap for you to close: the change is test-only, so unlike the other open branches it needs **no `npm run build`** and won't disturb the plugin your Obsidian is currently running.

```sh
git checkout test/mcp-session-cleanup
OBSIDIAN_API_KEY=<key> npm run test:integration
```

A green `src/integration/mcp.test.ts` is most of the proof. If you want the rest of it: the leak's effect originally showed up as an intermittent `vault_patch` frontmatter failure across repeated full-suite runs, so a handful of consecutive `npm run test:integration` runs is the measurement that would show the flake is gone rather than merely quiet.

Branched off `origin/main` at `df76d50`.
