### PR TITLE
Drop the vault_read UTF-8 notes from the Readme and MCP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,10 +347,6 @@ The REST API has always handled binary content: `GET /vault/<path>` returns raw 
 
 MCP tools are a different story, because a tool's arguments and results pass through the model. `vault_read` and `vault_write` are text tools — they decode and encode UTF-8, which is lossy for anything that is not text — so reading an attachment with `vault_read` and writing the result back destroys the file. `vault_read_binary` and `vault_write_binary` exist for those files, and carry the bytes base64-encoded.
 
-`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
-
-`vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
-
 `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 
 Because base64 costs roughly 0.35-0.45 tokens per byte of context, both binary tools refuse files over 1 MiB. That ceiling is a context guard, not a storage limit — move larger attachments over the REST endpoints above.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1461,10 +1461,6 @@ paths:
         
         `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
         
-        `vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
-        
-        `vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
-        
         `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
         
         Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.

--- a/docs/src/lib/descriptions/mcp.md
+++ b/docs/src/lib/descriptions/mcp.md
@@ -53,10 +53,6 @@ Requests with an unrecognized `MCP-Protocol-Version` value are rejected with `40
 
 `vault_read` and `vault_write` are text tools: they decode and encode UTF-8, which is lossy for anything that is not text, so reading an attachment through `vault_read` and writing the result back destroys the file. Use `vault_read_binary` and `vault_write_binary` for attachments instead. Both carry the file base64-encoded.
 
-`vault_read` refuses a file whose bytes are not valid UTF-8 rather than handing back the lossy string decoding it produces, and the refusal names `vault_read_binary`. A text file that happens to contain a U+FFFD replacement character is still read normally: the check is whether the file's own bytes are valid UTF-8, not whether that character appears in them.
-
-`vault_write` has no equivalent guard, and cannot: it takes a string, and a string is text by construction, so there is nothing to detect. The read-side refusal is what keeps the round trip that destroys a file from starting.
-
 `vault_write_binary` refuses a payload it cannot decode cleanly rather than writing the bytes it managed to salvage.
 
 Base64 in a tool argument or result passes through the model's context at roughly 0.35-0.45 tokens per byte, so both tools refuse files over 1 MiB. That is a context guard rather than a storage limit: `GET` and `PUT /vault/{filename}` carry raw bytes of any size at no context cost, and are the right way to move a large attachment.


### PR DESCRIPTION
Follow-up to PR 346, which you approved and merged with two inline comments asking that the documentation it added come back out — one on `docs/openapi.yaml`, one on `README.md`, both saying the same thing: *if the addressed content isn't UTF-8 and they use this endpoint, they'll get this information in the error message.*

So this removes the two paragraphs PR 346 added to the "Binary files" section in both places:

- the one describing `vault_read`'s refusal of non-UTF-8 bytes and the U+FFFD carve-out, and
- the one explaining that `vault_write` has no equivalent guard and cannot have one.

The first documents something the error message already says at the moment it matters, to someone who has already done the thing. The second documents an absence. What stays is the paragraph that predates PR 346 — the text tools are lossy for anything that isn't text, use `vault_read_binary` and `vault_write_binary` for attachments — which is the part a reader needs *before* they do anything wrong.

`docs/openapi.yaml` is regenerated from `docs/src/lib/descriptions/mcp.md` rather than hand-edited, per AGENTS.md.

## Risk

No source file is touched, so there is no behaviour to regress. `npm test` is 513 passing on the branch. The only reviewable question is an editorial one: whether the remaining paragraph is enough on its own, which is your call and the reason this is a PR rather than a push to main.

The integration suite still has not run against a live Obsidian — unchanged from PR 346, and unaffected by a documentation-only diff.